### PR TITLE
Add card search filter on Home

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,24 @@
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { trails } from "../data/trails";
 
 export default function Home() {
   const nav = useNavigate();
+  const [query, setQuery] = useState("");
+
+  const filteredTrails = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return trails;
+
+    return trails.filter((trail) => {
+      const titleMatch = trail.title.toLowerCase().includes(normalized);
+      const subtitleMatch = trail.subtitle.toLowerCase().includes(normalized);
+      const tagMatch = trail.tags.some((tag) =>
+        tag.toLowerCase().includes(normalized)
+      );
+      return titleMatch || subtitleMatch || tagMatch;
+    });
+  }, [query]);
 
   return (
     <div className="space-y-6">
@@ -13,44 +29,69 @@ export default function Home() {
         </p>
       </section>
 
+      <section className="rounded-3xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+        <label
+          htmlFor="trail-search"
+          className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+        >
+          Search
+        </label>
+        <input
+          id="trail-search"
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search by title, description, or tags"
+          className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-2 text-sm text-zinc-900 shadow-sm outline-none transition focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+        />
+      </section>
+
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        {trails.map((t) => (
-          <button
-            key={t.id}
-            onClick={() => nav(`/trail/${t.id}`)}
-            className="group rounded-3xl border border-zinc-200 bg-white p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900"
-          >
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <div className="text-base font-semibold">{t.title}</div>
-                <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-                  {t.subtitle}
+        {filteredTrails.length === 0 ? (
+          <div className="rounded-3xl border border-dashed border-zinc-200 bg-white p-6 text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400 md:col-span-2">
+            No results
+          </div>
+        ) : (
+          filteredTrails.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => nav(`/trail/${t.id}`)}
+              className="group rounded-3xl border border-zinc-200 bg-white p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <div className="text-base font-semibold">{t.title}</div>
+                  <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+                    {t.subtitle}
+                  </div>
+                </div>
+                <div className="rounded-2xl bg-zinc-100 px-3 py-2 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
+                  {t.minutes}m
                 </div>
               </div>
-              <div className="rounded-2xl bg-zinc-100 px-3 py-2 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
-                {t.minutes}m
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                {t.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full border border-zinc-200 px-2.5 py-1 text-xs text-zinc-600 dark:border-zinc-700 dark:text-zinc-300"
+                  >
+                    #{tag}
+                  </span>
+                ))}
               </div>
-            </div>
 
-            <div className="mt-4 flex flex-wrap gap-2">
-              {t.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded-full border border-zinc-200 px-2.5 py-1 text-xs text-zinc-600 dark:border-zinc-700 dark:text-zinc-300"
-                >
-                  #{tag}
+              <div className="mt-5 text-sm text-zinc-600 dark:text-zinc-300">
+                <span className="inline-flex items-center gap-1">
+                  Open detail
+                  <span className="transition group-hover:translate-x-0.5">
+                    →
+                  </span>
                 </span>
-              ))}
-            </div>
-
-            <div className="mt-5 text-sm text-zinc-600 dark:text-zinc-300">
-              <span className="inline-flex items-center gap-1">
-                Open detail
-                <span className="transition group-hover:translate-x-0.5">→</span>
-              </span>
-            </div>
-          </button>
-        ))}
+              </div>
+            </button>
+          ))
+        )}
       </section>
     </div>
   );


### PR DESCRIPTION
  ## Summary
  - What did you change? Added a search input on Home to filter cards by title, subtitle, and
  tags with a live, case-insensitive match and an empty state.
  - Why was it necessary? Improves navigation UX with a small, observable change.
  ## What changed
  - [x] UI
  - [x] State management
  - [ ] Refactor
  - [ ] Config/Tooling (only if requested)

  ## How to verify
  2) Type into the search input and confirm cards filter by title/subtitle/tags (case-
  insensitive).

  Commands:
  - `npm i`
  - `npm run build`
  - `npm run dev`

  ## Scope / Out of scope
  - In scope: Home search input and client-side filtering for title, subtitle, and tags.
  - Out of scope: URL/localStorage persistence, backend changes, redesign.

  ## Risks / trade-offs
  -

  ## Screenshots (optional)
  - N/A (not provided)

  ## Follow-ups
  -

  ## Open Questions
  -