### PR TITLE
chore: localize Issue template to Japanese

### DIFF
--- a/.github/ISSUE_TEMPLATE/codex_task.yml
+++ b/.github/ISSUE_TEMPLATE/codex_task.yml
@@ -1,43 +1,43 @@
 name: Codex Task
-description: Task for Codex (1 issue = 1 PR)
+description: Codex向けタスク（1 issue = 1 PR）
 title: "[Trailboard] "
 labels: ["codex"]
 body:
   - type: textarea
     id: goal
     attributes:
-      label: Goal
-      description: What outcome do you want?
-      placeholder: e.g., Add a search box to filter cards by title/tag.
+      label: 目的
+      description: どのような成果を求めますか？
+      placeholder: 例: タイトル/タグでカードを絞り込める検索ボックスを追加する。
     validations:
       required: true
 
   - type: textarea
     id: ac
     attributes:
-      label: Acceptance Criteria
-      description: Concrete conditions to be satisfied.
+      label: 受け入れ条件
+      description: 満たすべき具体的な条件。
       placeholder: |
-        - Typing filters cards instantly
-        - No new dependencies
-        - Build passes
+        - 入力すると即時にカードが絞り込まれる
+        - 新しい依存は追加しない
+        - ビルドが通る
     validations:
       required: true
 
   - type: textarea
     id: oos
     attributes:
-      label: Out of scope
-      description: Explicitly what not to do.
-      placeholder: e.g., No backend, no persistence, no design overhaul.
+      label: スコープ外
+      description: 対象外とする内容を明示する。
+      placeholder: 例: バックエンドなし、永続化なし、デザイン全面改修なし。
     validations:
       required: true
 
   - type: textarea
     id: notes
     attributes:
-      label: Notes
-      description: Any hints, constraints, or links.
-      placeholder: Optional
+      label: 補足
+      description: ヒント、制約、関連リンクなど。
+      placeholder: 任意
     validations:
       required: false


### PR DESCRIPTION
## 概要
  - .github/ISSUE_TEMPLATE/codex_task.yml の label / description / placeholder を日本語に翻訳しました。
  - Issueテンプレートを日本語化し、運用時の記述を日本語で統一するためです。
  ## 変更内容
  - [ ] UI
  - [ ] Routing
  - [ ] Refactor
  - [ ] Config/Tooling (only if requested)
  - [x] Other: Issueテンプレート文言の翻訳（構造変更なし）
  ## 検証方法
  1. .github/ISSUE_TEMPLATE/codex_task.yml を開く
  3. id / required / キー構造 / フィールド順序が変更されていないことを確認する
  コマンド:
  - npm i（未実行）
  - npm run build（未実行: 本Issue要件で不要）
  - npm run dev（未実行: 本Issue要件で不要）

  ## スコープ / スコープ外

  - スコープ内: .github/ISSUE_TEMPLATE/codex_task.yml の翻訳のみ（labels/descriptions/placeholders）
  - スコープ外: フィールド追加・削除、順序変更、キー変更、id/required変更、他ファイル変更

  ## リスク / トレードオフ

  - 文言の訳し方によるニュアンス差が発生する可能性はあるが、構造や意味は維持している。

  ## スクリーンショット（任意）

  - なし

  ## フォローアップ

  - なし

  ## 未解決の質問

  - なし