### PR TITLE
chore: FIX README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,18 @@ Open a PR using the provided template with clear verification steps.
 
 If any requirement is unclear, ask before making assumptions.
 ```
+
+## WSL (Ubuntu) に GitHub CLI (`gh`) を導入する
+
+```bash
+type -p curl >/dev/null || sudo apt install curl -y
+sudo mkdir -p -m 755 /etc/apt/keyrings
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+sudo apt update
+sudo apt install gh -y
+gh --version
+```


### PR DESCRIPTION
## 概要
  - README.md に「WSL (Ubuntu) に GitHub CLI (gh) を導入する」セクションを追記しました。
  - WSL Ubuntu環境で gh を公式aptリポジトリ経由で最小手順で導入できるようにするためです。
  ## 変更内容
  - [ ] UI
  - [ ] Routing
  - [ ] Refactor
  - [x] Other: ドキュメント追記（README.md のみ）
  ## 検証方法
  1. README.md を開く
  3. セクション内に公式aptリポジトリ手順と gh --version が含まれていることを確認する
  コマンド:
  - npm i（未実行）
  - npm run build（未実行: 本Issue要件で不要）
  - npm run dev（未実行）

  ## スコープ / スコープ外

  - スコープ内: README.md への短い手順セクション追記のみ
  - スコープ外: 他ファイル変更、既存内容の再構成、追加要件の導入

  ## リスク / トレードオフ

  - None

  ## スクリーンショット（任意）

  - なし

  ## フォローアップ

  - なし

  ## 未解決の質問

  - なし