### PR TITLE
add create card and localStorage usage

### DIFF
--- a/src/data/trails.ts
+++ b/src/data/trails.ts
@@ -6,6 +6,8 @@ export type Trail = {
   minutes: number;
 };
 
+export const CARD_STORAGE_KEY = "trailboard.cards.v1";
+
 export const trails: Trail[] = [
   {
     id: "a01",
@@ -30,6 +32,73 @@ export const trails: Trail[] = [
   },
 ];
 
+function isTrail(value: unknown): value is Trail {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<Trail>;
+
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.title === "string" &&
+    typeof candidate.subtitle === "string" &&
+    Array.isArray(candidate.tags) &&
+    candidate.tags.every((tag) => typeof tag === "string") &&
+    typeof candidate.minutes === "number"
+  );
+}
+
+export function loadStoredTrails(): Trail[] | null {
+  const raw = localStorage.getItem(CARD_STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    if (!parsed.every(isTrail)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function saveTrails(nextTrails: Trail[]) {
+  localStorage.setItem(CARD_STORAGE_KEY, JSON.stringify(nextTrails));
+}
+
+export function getPreferredTrails() {
+  return loadStoredTrails() ?? trails;
+}
+
+export function parseTags(raw: string): string[] {
+  const normalized = raw
+    .split(/[\s,]+/)
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .map((tag) => tag.replace(/^#+/, "").toLowerCase())
+    .filter(Boolean);
+
+  return Array.from(new Set(normalized));
+}
+
+export function parseDurationToMinutes(raw: string): number | null {
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) return null;
+
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10);
+  }
+
+  const withUnit = trimmed.match(/^(\d+)\s*m$/);
+  if (!withUnit) return null;
+  return Number.parseInt(withUnit[1], 10);
+}
+
+export function createTrailId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `trail-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
 export function getTrail(id: string) {
-  return trails.find((t) => t.id === id);
+  return getPreferredTrails().find((t) => t.id === id);
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,16 +1,31 @@
 import { useMemo, useState } from "react";
+import type { FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
-import { trails } from "../data/trails";
+import {
+  createTrailId,
+  getPreferredTrails,
+  parseDurationToMinutes,
+  parseTags,
+  saveTrails,
+} from "../data/trails";
+import type { Trail } from "../data/trails";
 
 export default function Home() {
   const nav = useNavigate();
   const [query, setQuery] = useState("");
+  const [items, setItems] = useState<Trail[]>(() => getPreferredTrails());
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [titleInput, setTitleInput] = useState("");
+  const [descriptionInput, setDescriptionInput] = useState("");
+  const [tagsInput, setTagsInput] = useState("");
+  const [durationInput, setDurationInput] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
 
   const filteredTrails = useMemo(() => {
     const normalized = query.trim().toLowerCase();
-    if (!normalized) return trails;
+    if (!normalized) return items;
 
-    return trails.filter((trail) => {
+    return items.filter((trail) => {
       const titleMatch = trail.title.toLowerCase().includes(normalized);
       const subtitleMatch = trail.subtitle.toLowerCase().includes(normalized);
       const tagMatch = trail.tags.some((tag) =>
@@ -18,15 +33,73 @@ export default function Home() {
       );
       return titleMatch || subtitleMatch || tagMatch;
     });
-  }, [query]);
+  }, [items, query]);
+
+  function closeModal() {
+    setIsModalOpen(false);
+    setFormError(null);
+  }
+
+  function resetForm() {
+    setTitleInput("");
+    setDescriptionInput("");
+    setTagsInput("");
+    setDurationInput("");
+    setFormError(null);
+  }
+
+  function handleOpenModal() {
+    resetForm();
+    setIsModalOpen(true);
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const title = titleInput.trim();
+    if (!title) {
+      setFormError("Title is required.");
+      return;
+    }
+
+    const minutes = parseDurationToMinutes(durationInput);
+    if (durationInput.trim() && minutes === null) {
+      setFormError("Duration must be a number or format like 12m.");
+      return;
+    }
+
+    const nextTrail: Trail = {
+      id: createTrailId(),
+      title,
+      subtitle: descriptionInput.trim() || "No description",
+      tags: parseTags(tagsInput),
+      minutes: minutes ?? 0,
+    };
+
+    const nextTrails = [nextTrail, ...items];
+    setItems(nextTrails);
+    saveTrails(nextTrails);
+    closeModal();
+  }
 
   return (
     <div className="space-y-6">
       <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-        <h1 className="text-xl font-semibold">今日のボード</h1>
-        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-          カードをクリックすると詳細へ遷移します（データはフロント内のモックです）
-        </p>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-xl font-semibold">今日のボード</h1>
+            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+              カードをクリックすると詳細へ遷移します（データはフロント内のモックです）
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleOpenModal}
+            className="shrink-0 rounded-xl bg-zinc-900 px-3 py-2 text-sm text-white hover:opacity-90 dark:bg-zinc-100 dark:text-zinc-900"
+          >
+            + New
+          </button>
+        </div>
       </section>
 
       <section className="rounded-3xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
@@ -93,6 +166,83 @@ export default function Home() {
           ))
         )}
       </section>
+
+      {isModalOpen && (
+        <div className="fixed inset-0 z-20 flex items-end justify-center bg-zinc-950/40 p-4 sm:items-center">
+          <form
+            onSubmit={handleSubmit}
+            className="w-full max-w-md rounded-3xl border border-zinc-200 bg-white p-5 shadow-lg dark:border-zinc-800 dark:bg-zinc-900"
+          >
+            <h2 className="text-lg font-semibold">Create Card</h2>
+            <div className="mt-4 space-y-3">
+              <label className="block text-sm">
+                <span className="mb-1 block text-zinc-700 dark:text-zinc-300">
+                  Title *
+                </span>
+                <input
+                  value={titleInput}
+                  onChange={(event) => setTitleInput(event.target.value)}
+                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                />
+              </label>
+              <label className="block text-sm">
+                <span className="mb-1 block text-zinc-700 dark:text-zinc-300">
+                  Description
+                </span>
+                <input
+                  value={descriptionInput}
+                  onChange={(event) => setDescriptionInput(event.target.value)}
+                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                />
+              </label>
+              <label className="block text-sm">
+                <span className="mb-1 block text-zinc-700 dark:text-zinc-300">
+                  Tags
+                </span>
+                <input
+                  value={tagsInput}
+                  onChange={(event) => setTagsInput(event.target.value)}
+                  placeholder="#calm #reset"
+                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                />
+              </label>
+              <label className="block text-sm">
+                <span className="mb-1 block text-zinc-700 dark:text-zinc-300">
+                  Duration
+                </span>
+                <input
+                  value={durationInput}
+                  onChange={(event) => setDurationInput(event.target.value)}
+                  placeholder="12 or 12m"
+                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                />
+              </label>
+            </div>
+
+            {formError && (
+              <p className="mt-3 text-sm text-red-600 dark:text-red-400">
+                {formError}
+              </p>
+            )}
+
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeModal}
+                className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-800 dark:hover:bg-zinc-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="rounded-xl bg-zinc-900 px-4 py-2 text-sm text-white hover:opacity-90 dark:bg-zinc-100 dark:text-zinc-900"
+              >
+                Save
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 概要
  - Home画面でカード追加を可能にし、作成カードを localStorage に保存・復元できるようにしました。
    した。

## 変更内容
- [x] UI
- [x] Routing
- [ ] State management
- [ ] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/data/trails.ts
      - CARD_STORAGE_KEY として trailboard.cards.v1 を追加。
      - loadStoredTrails / saveTrails / getPreferredTrails を追加。
      - parseTags（# 有無吸収・小文字化・重複除去）を追加。
      - parseDurationToMinutes（12 / 12m 対応）を追加。
      - createTrailId（crypto.randomUUID() 優先 + fallback）を追加。
      - getTrail を保存データ優先参照に変更。
      - 一覧データを state 化し、初期値を getPreferredTrails() に変更。
      - 「+ New」導線を追加。
      - 既存検索（title/description/tags）を追加カードにも適用。

## 検証方法
  1. npm run dev を起動し Home 画面を開く。
  2. 右上の + New を押してモーダルを開く。
      - description: 任意
      - tags: 例 #calm #focus
      - duration: 12 または 12m
  4. 保存直後にカードが一覧に表示されることを確認。
  6. ページをリロードして、追加カードが残っていることを確認。
  7. Application > Local Storage でキー trailboard.cards.v1 に JSON 配列が保存されていることを確認。

  - npm run build（実行済み・成功）

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
  - Homeでのカード作成、一覧反映、localStorage保存/復元
  - 保存データ優先読み込み
  - 既存検索への追加カード適用
- スコープ外:
  - カード編集・削除
  - ソート
  - バックエンド同期
  - Settings拡張
  - 全面デザイン改修
  - 既存データ構造の大規模変更
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - 既に不正な形式の trailboard.cards.v1 が存在する環境ではフォールバックしてモック表示になります（安全側挙
    動）。
  - duration 未入力時は 0m 表示になります（要件内だが、表示方針としては将来見直し余地あり）。
 
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - duration 未入力時の表示を - などにするかを決める。
  - 追加フォームに Enter送信時のフォーカス制御やEsc閉じる挙動を必要なら追加。

## 未解決の質問
- 
