### PR TITLE
add deletion card function

### DIFF
--- a/src/data/trails.ts
+++ b/src/data/trails.ts
@@ -102,3 +102,14 @@ export function createTrailId() {
 export function getTrail(id: string) {
   return getPreferredTrails().find((t) => t.id === id);
 }
+
+export function deleteTrail(id: string): boolean {
+  const current = getPreferredTrails();
+  const next = current.filter((trail) => trail.id !== id);
+  if (next.length === current.length) {
+    return false;
+  }
+
+  saveTrails(next);
+  return true;
+}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,9 +1,20 @@
-import { Link, useParams } from "react-router-dom";
-import { getTrail } from "../data/trails";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { deleteTrail, getTrail } from "../data/trails";
 
 export default function Detail() {
+  const navigate = useNavigate();
   const { id } = useParams();
   const t = id ? getTrail(id) : undefined;
+
+  function handleDelete() {
+    if (!id) return;
+
+    const confirmed = window.confirm("Delete this card?");
+    if (!confirmed) return;
+
+    deleteTrail(id);
+    navigate("/", { replace: true });
+  }
 
   if (!t) {
     return (
@@ -54,6 +65,13 @@ export default function Detail() {
           >
             Settings
           </Link>
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-100 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          >
+            Delete
+          </button>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## 概要
  - カード詳細画面から単体カードを削除できる機能を追加し、削除結果が localStorage に永続化されるようにしました。
    これによりリロード後も削除状態が維持されます。

## 変更内容
- [x] UI
- [x] Routing
- [ ] State management
- [ ] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/pages/Detail.tsx:1
      - Delete ボタンを追加。
      - window.confirm("Delete this card?") による削除確認を追加。
      - OK時のみ削除処理を実行し、/ へ navigate("/", { replace: true }) で自然遷移。
      - Cancel時は何も変更しない挙動。
  - src/data/trails.ts:106
      - deleteTrail(id: string): boolean を追加。
      - filter で対象 id を除外して保存。
      - 対象が見つからない場合は false を返して安全に終了（クラッシュしないガード）。


## 検証方法
  1. npm run build
  2. （手動）Home から任意カードの Open detail を開く。
  3. Delete を押して確認ダイアログで Cancel を選ぶ。
      - カードは削除されず表示も変わらないことを確認。
  4. 再度 Delete を押して OK を選ぶ。
      - 一覧に戻り、対象カードが消えていることを確認。
  5. ページをリロードし、削除カードが復活しないことを確認。
  6. Search で残存カードの検索が従来通り動くことを確認。

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
      - 詳細画面での単体削除
      - 削除確認
      - 削除後遷移
      - localStorage 反映と永続化
- スコープ外:
      - 編集機能
      - 複数/一括削除
      - ゴミ箱/Undo
      - Export/Import
      - バックエンド導入・同期
      - UI全面改修
     
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
 - deleteTrail は削除時に最新配列を再取得して保存する実装のため、同時に複数タブで更新した場合の競合解決は未対応
    （現行設計の範囲内）。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要なら削除成功/失敗のトースト表示を追加可能。

## 未解決の質問
- 
