### PR TITLE
add card edit function

### DIFF
--- a/src/data/trails.ts
+++ b/src/data/trails.ts
@@ -113,3 +113,20 @@ export function deleteTrail(id: string): boolean {
   saveTrails(next);
   return true;
 }
+
+export function updateTrail(
+  id: string,
+  payload: Omit<Trail, "id">
+): Trail | null {
+  const current = getPreferredTrails();
+  const targetIndex = current.findIndex((trail) => trail.id === id);
+  if (targetIndex === -1) return null;
+
+  const updatedTrail: Trail = {
+    id,
+    ...payload,
+  };
+  const next = current.map((trail) => (trail.id === id ? updatedTrail : trail));
+  saveTrails(next);
+  return updatedTrail;
+}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,13 +1,83 @@
 import { useState } from "react";
+import type { FormEvent } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { deleteTrail, getTrail } from "../data/trails";
+import {
+  deleteTrail,
+  getTrail,
+  parseDurationToMinutes,
+  parseTags,
+  updateTrail,
+} from "../data/trails";
 
 export default function Detail() {
   const navigate = useNavigate();
   const { id } = useParams();
   const trail = id ? getTrail(id) : undefined;
   const [deletingTrailId, setDeletingTrailId] = useState<string | null>(null);
+  const [editingTrailId, setEditingTrailId] = useState<string | null>(null);
+  const [titleInput, setTitleInput] = useState("");
+  const [descriptionInput, setDescriptionInput] = useState("");
+  const [tagsInput, setTagsInput] = useState("");
+  const [durationInput, setDurationInput] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
   const isDeleting = Boolean(id && deletingTrailId === id);
+  const isEditing = Boolean(id && editingTrailId === id);
+
+  function resetEditForm() {
+    setTitleInput("");
+    setDescriptionInput("");
+    setTagsInput("");
+    setDurationInput("");
+    setFormError(null);
+  }
+
+  function handleStartEdit() {
+    if (!id || !trail) return;
+
+    setEditingTrailId(id);
+    setTitleInput(trail.title);
+    setDescriptionInput(trail.subtitle === "No description" ? "" : trail.subtitle);
+    setTagsInput(trail.tags.map((tag) => `#${tag}`).join(" "));
+    setDurationInput(trail.minutes > 0 ? String(trail.minutes) : "");
+    setFormError(null);
+  }
+
+  function handleCancelEdit() {
+    setEditingTrailId(null);
+    resetEditForm();
+  }
+
+  function handleSaveEdit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!id || !trail) return;
+
+    const title = titleInput.trim();
+    if (!title) {
+      setFormError("Title is required.");
+      return;
+    }
+
+    const minutes = parseDurationToMinutes(durationInput);
+    if (durationInput.trim() && minutes === null) {
+      setFormError("Duration must be a number or format like 12m.");
+      return;
+    }
+
+    const updated = updateTrail(id, {
+      title,
+      subtitle: descriptionInput.trim() || "No description",
+      tags: parseTags(tagsInput),
+      minutes: minutes ?? 0,
+    });
+
+    if (!updated) {
+      setFormError("Card not found.");
+      return;
+    }
+
+    setEditingTrailId(null);
+    resetEditForm();
+  }
 
   function handleDelete() {
     if (!id || isDeleting) return;
@@ -71,6 +141,13 @@ export default function Detail() {
           </Link>
           <button
             type="button"
+            onClick={handleStartEdit}
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-100 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          >
+            Edit
+          </button>
+          <button
+            type="button"
             onClick={handleDelete}
             disabled={isDeleting}
             className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-100 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-800"
@@ -78,6 +155,74 @@ export default function Detail() {
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         </div>
+
+        {isEditing && (
+          <form onSubmit={handleSaveEdit} className="mt-6 space-y-3 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800">
+            <h2 className="text-sm font-semibold">Edit card</h2>
+            <label className="block text-sm">
+              <span className="mb-1 block text-zinc-700 dark:text-zinc-300">
+                Title *
+              </span>
+              <input
+                value={titleInput}
+                onChange={(event) => setTitleInput(event.target.value)}
+                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="mb-1 block text-zinc-700 dark:text-zinc-300">
+                Description
+              </span>
+              <input
+                value={descriptionInput}
+                onChange={(event) => setDescriptionInput(event.target.value)}
+                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="mb-1 block text-zinc-700 dark:text-zinc-300">
+                Tags
+              </span>
+              <input
+                value={tagsInput}
+                onChange={(event) => setTagsInput(event.target.value)}
+                placeholder="#calm #reset"
+                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="mb-1 block text-zinc-700 dark:text-zinc-300">
+                Duration
+              </span>
+              <input
+                value={durationInput}
+                onChange={(event) => setDurationInput(event.target.value)}
+                placeholder="12 or 12m"
+                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+              />
+            </label>
+
+            {formError && (
+              <p className="text-sm text-red-600 dark:text-red-400">{formError}</p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={handleCancelEdit}
+                className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-800 dark:hover:bg-zinc-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="rounded-xl bg-zinc-900 px-4 py-2 text-sm text-white hover:opacity-90 dark:bg-zinc-100 dark:text-zinc-900"
+              >
+                Save
+              </button>
+            </div>
+          </form>
+        )}
       </section>
     </div>
   );


### PR DESCRIPTION
## 概要
  - カード詳細ページ (/trail/:id) にインライン編集導線を追加し、保存時に対象カードを id で更新して localStorage
    に永続化するようにしました。
  - これにより、編集内容が詳細表示に即時反映され、一覧へ戻った後やリロード後も保持されます。

## 変更内容
- [x] UI
- [x] Routing
- [ ] State management
- [ ] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/data/trails.ts:117
      - updateTrail(id, payload) を追加。
      - getPreferredTrails() から対象 id を更新し、saveTrails(next) で保存。
  - src/pages/Detail.tsx:4
      - parseTags / parseDurationToMinutes / updateTrail を利用する編集処理を追加。
  - src/pages/Detail.tsx:17
      - 編集UI状態 (editingTrailId) とフォーム状態 (titleInput, descriptionInput, tagsInput, durationInput,
        formError) を追加。
  - src/pages/Detail.tsx:34
      - Edit ボタン押下で現在カード内容をフォームに初期化して表示。
  - src/pages/Detail.tsx:50
      - Save で以下を実装:
      - title 必須チェック
      - duration の既存仕様準拠パース（数値 or 12m）
      - tags の # 吸収・空要素除外（parseTags）
      - updateTrail 実行後にフォームを閉じて初期化
  - src/pages/Detail.tsx:159
      - 最小UIのインライン編集フォーム（Title/Description/Tags/Duration、Save/Cancel）を追加。
  - 既存の Delete 動線は維持（表示は常時、押下中のみ disabled）。

## 検証方法
  - 実行コマンド（実施済み）
      - npm run lint
      - npm run build
  - 手動確認
      1. /trail/:id を開き Edit を押してフォームが開くことを確認。
      2. title / description / tags / duration を変更して Save。
      3. 詳細表示が更新されることを確認。
      4. 一覧へ戻って同カードのタイトル/説明/タグ/時間が反映されることを確認。
      5. ページをリロードして更新が保持されることを確認。
      6. Cancel で表示が変わらないことを確認。
      7. 検索（title/description/tags）が従来通り機能することを確認。

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
      - 詳細ページでの単体カード編集機能と永続化反映。
- スコープ外:
      - 編集履歴、Undo/Redo、一括編集、バックエンド導入、ルーティング大改修。
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - description を空で保存した場合は既存仕様に合わせて "No description" を保存します（空文字保持にはしていませ
    ん）。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要なら、Home の新規作成フォームと編集フォームの共通化（重複削減）を検討可能です。

## 未解決の質問
- 
