### PR TITLE
fix card details

### DIFF
--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -126,23 +126,17 @@ export default function Detail() {
           </div>
         </div>
 
-        <div className="mt-6 flex gap-3">
+        <div className="mt-6 flex flex-wrap gap-3">
           <Link
             to="/"
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-800 dark:hover:bg-zinc-800"
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm transition-colors transition-shadow hover:border-zinc-300 hover:bg-zinc-100 hover:shadow-sm dark:border-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-800"
           >
             Back
-          </Link>
-          <Link
-            to="/settings"
-            className="rounded-xl bg-zinc-900 px-4 py-2 text-sm text-white hover:opacity-90 dark:bg-zinc-100 dark:text-zinc-900"
-          >
-            Settings
           </Link>
           <button
             type="button"
             onClick={handleStartEdit}
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-100 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors transition-shadow hover:border-zinc-300 hover:bg-zinc-100 hover:shadow-sm dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-700 dark:hover:bg-zinc-800"
           >
             Edit
           </button>
@@ -150,7 +144,7 @@ export default function Detail() {
             type="button"
             onClick={handleDelete}
             disabled={isDeleting}
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-100 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors transition-shadow hover:border-red-200 hover:bg-red-50 hover:text-red-700 hover:shadow-sm dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-red-900/70 dark:hover:bg-red-950/40 dark:hover:text-red-300"
           >
             {isDeleting ? "Deleting..." : "Delete"}
           </button>


### PR DESCRIPTION
## 概要
  Issue #29 対応として、/trail/:id の下部ボタン列から不要な Settings を削除し、Back / Edit / Delete の hover 視
  認性を改善しました。特に Delete は hover 時のみ薄赤トーンになるようにして危険操作を示しています。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/pages/Detail.tsx:129 下部ボタン列を flex flex-wrap に変更し、ボタン削除後の崩れを防止。
  - src/pages/Detail.tsx:132 Back ボタンの hover を背景・枠・影で明確化。
  - src/pages/Detail.tsx:138 Settings ボタン（下部）を削除。上部ナビ側は未変更。
  - src/pages/Detail.tsx:142 Edit ボタンの hover を背景・枠・影で明確化。
  - src/pages/Detail.tsx:148 Delete ボタンの hover を薄赤背景＋赤寄り文字/枠に変更（通常時トーンは維持）。

## 検証方法
  1. npm run build
  2. npm run dev を起動し、/trail/:id を開く。
  3. 下部ボタン列に Settings がないことを確認。
  4. Back / Edit / Delete が表示され、レイアウト崩れがないことを確認。
  5. 各ボタン hover で視覚変化があることを確認。
  6. Delete の hover が薄赤系であることを確認。

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:/trail/:id の下部ボタン列の表示・hoverスタイル改善
- スコープ外:全面デザイン改修、ボタン配置の大規模再設計、ショートカット追加
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - Delete hover の赤トーンは環境のカラープロファイルによって見え方に差が出る可能性があります。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
- 

## 未解決の質問
- 
