### PR TITLE
create Light/Dark mode

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,15 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
 
+const THEME_STORAGE_KEY = "trailboard.theme";
+const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+
+if (savedTheme === "dark") {
+  document.documentElement.classList.add("dark");
+} else {
+  document.documentElement.classList.remove("dark");
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 
 type Theme = "light" | "dark";
+const THEME_STORAGE_KEY = "trailboard.theme";
 
 export default function Settings() {
   const initial = useMemo<Theme>(() => {
-    const saved = localStorage.getItem("theme");
+    const saved = localStorage.getItem(THEME_STORAGE_KEY);
     return saved === "dark" ? "dark" : "light";
   }, []);
 
@@ -14,7 +15,7 @@ export default function Settings() {
     const html = document.documentElement;
     if (theme === "dark") html.classList.add("dark");
     else html.classList.remove("dark");
-    localStorage.setItem("theme", theme);
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
 
   return (


### PR DESCRIPTION
## 概要
  Settings の Light/Dark 選択で全体テーマが切り替わるようにし、選択値を localStorage の trailboard.theme に保存してリロード
  後も維持されるようにしました。初回ロード時にも保存テーマを html.dark へ即時反映するため、/settings 以外の画面でも前回テー
  マが適用されます。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/main.tsx:7
      - テーマ保存キー trailboard.theme を読み取り、起動時に document.documentElement.classList へ dark を適用/解除する処理
        を追加。
  - src/pages/Settings.tsx:4
      - テーマ保存キーを "theme" から "trailboard.theme" に変更。
      - 初期値読み込み (light / dark) と保存処理を同キーに統一。
  - 既存の Light/Dark 選択 UI（アクティブ時の見た目切替）はそのまま維持。

## 検証方法
  1. 実行済み: npm run build（成功）
  2. 未実施（手元確認用）: npm run dev を起動し /settings で Dark を選択すると全体がダークになること
  3. 未実施（手元確認用）: localStorage.getItem("trailboard.theme") が "light" または "dark" になること
  4. 未実施（手元確認用）: ページをリロード後も前回テーマが維持されること

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:Light/Dark 切替の全体反映、localStorage 永続化、リロード時の再適用
- スコープ外:prefers-color-scheme 追従、多色テーマ化、サーバ同期
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
 - テーマ初期適用を main.tsx のトップレベルで実行しているため、将来 SSR 対応時には実行環境ガードが必要です。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
- 

## 未解決の質問
- 
