### PR TITLE
fix details

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { Outlet, Link, useLocation } from "react-router-dom";
 
 export default function Layout() {
   const loc = useLocation();
+  const isHomeActive = loc.pathname === "/" || loc.pathname.startsWith("/trail/");
 
   return (
     <div className="min-h-dvh">
@@ -21,7 +22,7 @@ export default function Layout() {
             <Link
               to="/"
               className={`rounded-xl px-3 py-2 text-sm ${
-                loc.pathname === "/"
+                isHomeActive
                   ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                   : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900"
               }`}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -136,7 +136,7 @@ export default function Detail() {
           <button
             type="button"
             onClick={handleStartEdit}
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors transition-shadow hover:border-zinc-300 hover:bg-zinc-100 hover:shadow-sm dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-zinc-700 dark:hover:bg-zinc-800"
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors transition-shadow hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700 hover:shadow-sm dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-emerald-900/70 dark:hover:bg-emerald-950/40 dark:hover:text-emerald-300"
           >
             Edit
           </button>


### PR DESCRIPTION
## 概要
  /trail/:id を Home 配下として扱うようにヘッダのアクティブ判定を修正し、詳細ページの Edit ボタン hover を薄グリーン系に変更しました。これにより現在地の認知と操作意図（編集は安全寄り）が分かりやすくなります。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/components/Layout.tsx:5
      - isHomeActive を追加: loc.pathname === "/" || loc.pathname.startsWith("/trail/")
  - src/components/Layout.tsx:24
      - Home ナビのアクティブ判定を loc.pathname === "/" から isHomeActive に変更
  - src/pages/Detail.tsx:139
      - 詳細ページの Edit ボタン hover を薄グリーン系へ変更
      - hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700
      - dark 時も dark:hover:border-emerald-900/70 dark:hover:bg-emerald-950/40 dark:hover:text-emerald-300

## 検証方法
  1. npm run build
  2. npm run dev
  3. / で Home がアクティブ表示であることを確認
  4. /trail/<id> で Home がアクティブ表示であることを確認
  5. /settings で Settings がアクティブ表示であることを確認
  6. /trail/<id> の Edit hover が薄グリーンで、Delete の薄赤 hover と他ボタン hover が維持されていることを確認

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
      - ナビのアクティブ判定ロジック（Home のみ）
      - 詳細ページの Edit ボタン hover 色
- スコープ外:
      - ナビ項目追加
      - ルーティング構造変更
      - UI 全面改修
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - pathname.startsWith("/trail/") 前提のため、将来 /trail 配下の命名を大きく変える場合は判定更新が必要です。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
- 

## 未解決の質問
- 
