### PR TITLE
create 404 fallback to home

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Redirecting...</title>
+  </head>
+  <body>
+    <script>
+      (function () {
+        var isProjectPath = window.location.pathname.startsWith("/trailboard/");
+        var targetPath = isProjectPath ? "/trailboard/" : "/";
+        window.location.replace(window.location.origin + targetPath);
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## 概要
  GitHub Pages の深いURLアクセス時 404 対策として public/404.html を追加し、/trail/:id などでリロード・直アクセ
  スしてもアプリの Home へ戻れるようにしました。

## 変更内容
- [ ] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [x] Config/Tooling (only if requested)
- [x] Other:

  - public/404.html を新規追加。
  - 404 ページ表示時に JavaScript で Home へリダイレクトする処理を実装。
  - 配備先を考慮し、/trailboard/* 配下なら /trailboard/、それ以外は / に遷移するようにしています。

## 検証方法
  1. 実行済み: npm run build（成功）
  2. GitHub Pages 配備後に /trail/:id を開いた状態でリロードし、404で停止せず Home が表示されることを確認
  3. GitHub Pages 配備後に URL バーへ /trail/:id を直接入力し、404で停止せず Home が表示されることを確認
  4. 通常の画面遷移（Home→Detail→Settings）が壊れていないことを確認

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
  - GitHub Pages での SPA deep link 404 時に「Homeへ戻せる」最小対応のみ
- スコープ外:
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - 404 時は元の詳細ページ復元ではなく Home へ遷移します（Issue の許容範囲内）。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要なら将来、404.html + クエリ引き継ぎ方式で元URL復元に拡張可能です。

## 未解決の質問
- 
