### PR TITLE
Soften dark theme

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,7 +6,7 @@ export default function Layout() {
 
   return (
     <div className="min-h-dvh">
-      <header className="sticky top-0 z-10 border-b border-zinc-200/60 bg-white/70 backdrop-blur dark:border-zinc-800/60 dark:bg-zinc-950/70">
+      <header className="sticky top-0 z-10 border-b border-zinc-200/60 bg-white/70 backdrop-blur dark:border-zinc-700/60 dark:bg-zinc-900/70">
         <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
           <Link to="/" className="flex items-center gap-2">
             <div className="h-8 w-8 rounded-xl bg-zinc-900 dark:bg-zinc-100" />
@@ -24,7 +24,7 @@ export default function Layout() {
               className={`rounded-xl px-3 py-2 text-sm ${
                 isHomeActive
                   ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
-                  : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900"
+                  : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
               }`}
             >
               Home
@@ -34,7 +34,7 @@ export default function Layout() {
               className={`rounded-xl px-3 py-2 text-sm ${
                 loc.pathname === "/settings"
                   ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
-                  : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900"
+                  : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
               }`}
             >
               Settings

--- a/src/index.css
+++ b/src/index.css
@@ -11,5 +11,5 @@ html.dark {
 }
 
 body {
-  @apply bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100;
+  @apply bg-zinc-50 text-zinc-900 dark:bg-zinc-900 dark:text-zinc-100;
 }

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -92,7 +92,7 @@ export default function Detail() {
 
   if (!trail) {
     return (
-      <div className="rounded-3xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="rounded-3xl border border-zinc-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-800">
         <div className="text-sm text-zinc-500">Not found</div>
         <Link className="mt-3 inline-block text-sm underline" to="/">
           Back to Home
@@ -103,7 +103,7 @@ export default function Detail() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
         <div className="text-xs text-zinc-500 dark:text-zinc-400">Trail ID: {trail.id}</div>
         <h1 className="mt-2 text-2xl font-semibold">{trail.title}</h1>
         <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">{trail.subtitle}</p>
@@ -119,7 +119,7 @@ export default function Detail() {
           ))}
         </div>
 
-        <div className="mt-6 rounded-2xl border border-zinc-200 p-4 text-sm text-zinc-700 dark:border-zinc-800 dark:text-zinc-200">
+        <div className="mt-6 rounded-2xl border border-zinc-200 p-4 text-sm text-zinc-700 dark:border-zinc-700 dark:text-zinc-200">
           <div className="font-medium">Mini interaction</div>
           <div className="mt-1 text-zinc-500 dark:text-zinc-400">
             ここは将来「フロントだけの状態管理」や「アニメーション実験」を足していく余地にします。
@@ -129,14 +129,14 @@ export default function Detail() {
         <div className="mt-6 flex flex-wrap gap-3">
           <Link
             to="/"
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm transition-colors transition-shadow hover:border-zinc-300 hover:bg-zinc-100 hover:shadow-sm dark:border-zinc-800 dark:hover:border-zinc-700 dark:hover:bg-zinc-800"
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm transition-colors transition-shadow hover:border-zinc-300 hover:bg-zinc-100 hover:shadow-sm dark:border-zinc-700 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
           >
             Back
           </Link>
           <button
             type="button"
             onClick={handleStartEdit}
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors transition-shadow hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700 hover:shadow-sm dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-emerald-900/70 dark:hover:bg-emerald-950/40 dark:hover:text-emerald-300"
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors transition-shadow hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700 hover:shadow-sm dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-emerald-900/70 dark:hover:bg-emerald-950/40 dark:hover:text-emerald-300"
           >
             Edit
           </button>
@@ -144,14 +144,14 @@ export default function Detail() {
             type="button"
             onClick={handleDelete}
             disabled={isDeleting}
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors transition-shadow hover:border-red-200 hover:bg-red-50 hover:text-red-700 hover:shadow-sm dark:border-zinc-800 dark:text-zinc-300 dark:hover:border-red-900/70 dark:hover:bg-red-950/40 dark:hover:text-red-300"
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors transition-shadow hover:border-red-200 hover:bg-red-50 hover:text-red-700 hover:shadow-sm dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-red-900/70 dark:hover:bg-red-950/40 dark:hover:text-red-300"
           >
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         </div>
 
         {isEditing && (
-          <form onSubmit={handleSaveEdit} className="mt-6 space-y-3 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800">
+          <form onSubmit={handleSaveEdit} className="mt-6 space-y-3 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-700">
             <h2 className="text-sm font-semibold">Edit card</h2>
             <label className="block text-sm">
               <span className="mb-1 block text-zinc-700 dark:text-zinc-300">
@@ -160,7 +160,7 @@ export default function Detail() {
               <input
                 value={titleInput}
                 onChange={(event) => setTitleInput(event.target.value)}
-                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
               />
             </label>
             <label className="block text-sm">
@@ -170,7 +170,7 @@ export default function Detail() {
               <input
                 value={descriptionInput}
                 onChange={(event) => setDescriptionInput(event.target.value)}
-                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
               />
             </label>
             <label className="block text-sm">
@@ -181,7 +181,7 @@ export default function Detail() {
                 value={tagsInput}
                 onChange={(event) => setTagsInput(event.target.value)}
                 placeholder="#calm #reset"
-                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
               />
             </label>
             <label className="block text-sm">
@@ -192,7 +192,7 @@ export default function Detail() {
                 value={durationInput}
                 onChange={(event) => setDurationInput(event.target.value)}
                 placeholder="12 or 12m"
-                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
               />
             </label>
 
@@ -204,7 +204,7 @@ export default function Detail() {
               <button
                 type="button"
                 onClick={handleCancelEdit}
-                className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-800 dark:hover:bg-zinc-800"
+                className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
               >
                 Cancel
               </button>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -113,7 +113,7 @@ export default function Home() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
         <div className="flex items-start justify-between gap-3">
           <div>
             <h1 className="text-xl font-semibold">今日のボード</h1>
@@ -131,7 +131,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="rounded-3xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <section className="rounded-3xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
         <label
           htmlFor="trail-search"
           className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
@@ -144,7 +144,7 @@ export default function Home() {
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           placeholder="Search by title, description, or tags"
-          className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-2 text-sm text-zinc-900 shadow-sm outline-none transition focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+          className="w-full rounded-2xl border border-zinc-200 bg-white px-4 py-2 text-sm text-zinc-900 shadow-sm outline-none transition focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
         />
 
         <div className="mt-4 space-y-2">
@@ -178,7 +178,7 @@ export default function Home() {
                     className={`rounded-full border px-3 py-1 text-xs transition-colors ${
                       isSelected
                         ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
-                        : "border-zinc-200 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        : "border-zinc-200 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-700"
                     }`}
                   >
                     #{tag} ({count})
@@ -192,7 +192,7 @@ export default function Home() {
 
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
         {filteredTrails.length === 0 ? (
-          <div className="rounded-3xl border border-dashed border-zinc-200 bg-white p-6 text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400 md:col-span-2">
+          <div className="rounded-3xl border border-dashed border-zinc-200 bg-white p-6 text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400 md:col-span-2">
             No results
           </div>
         ) : (
@@ -200,7 +200,7 @@ export default function Home() {
             <button
               key={t.id}
               onClick={() => nav(`/trail/${t.id}`)}
-              className="group rounded-3xl border border-zinc-200 bg-white p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900"
+              className="group rounded-3xl border border-zinc-200 bg-white p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-zinc-700 dark:bg-zinc-800"
             >
               <div className="flex items-start justify-between gap-4">
                 <div>
@@ -209,7 +209,7 @@ export default function Home() {
                     {t.subtitle}
                   </div>
                 </div>
-                <div className="rounded-2xl bg-zinc-100 px-3 py-2 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
+                <div className="rounded-2xl bg-zinc-100 px-3 py-2 text-xs font-medium text-zinc-700 dark:bg-zinc-700 dark:text-zinc-200">
                   {t.minutes}m
                 </div>
               </div>
@@ -242,7 +242,7 @@ export default function Home() {
         <div className="fixed inset-0 z-20 flex items-end justify-center bg-zinc-950/40 p-4 sm:items-center">
           <form
             onSubmit={handleSubmit}
-            className="w-full max-w-md rounded-3xl border border-zinc-200 bg-white p-5 shadow-lg dark:border-zinc-800 dark:bg-zinc-900"
+            className="w-full max-w-md rounded-3xl border border-zinc-200 bg-white p-5 shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
           >
             <h2 className="text-lg font-semibold">Create Card</h2>
             <div className="mt-4 space-y-3">
@@ -253,7 +253,7 @@ export default function Home() {
                 <input
                   value={titleInput}
                   onChange={(event) => setTitleInput(event.target.value)}
-                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
                 />
               </label>
               <label className="block text-sm">
@@ -263,7 +263,7 @@ export default function Home() {
                 <input
                   value={descriptionInput}
                   onChange={(event) => setDescriptionInput(event.target.value)}
-                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
                 />
               </label>
               <label className="block text-sm">
@@ -274,7 +274,7 @@ export default function Home() {
                   value={tagsInput}
                   onChange={(event) => setTagsInput(event.target.value)}
                   placeholder="#calm #reset"
-                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
                 />
               </label>
               <label className="block text-sm">
@@ -285,7 +285,7 @@ export default function Home() {
                   value={durationInput}
                   onChange={(event) => setDurationInput(event.target.value)}
                   placeholder="12 or 12m"
-                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-800 dark:bg-zinc-950 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                  className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
                 />
               </label>
             </div>
@@ -300,7 +300,7 @@ export default function Home() {
               <button
                 type="button"
                 onClick={closeModal}
-                className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-800 dark:hover:bg-zinc-800"
+                className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
               >
                 Cancel
               </button>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -20,7 +20,7 @@ export default function Settings() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
         <h1 className="text-xl font-semibold">Settings</h1>
         <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
           テーマを選択できます(Light/Dark)
@@ -32,7 +32,7 @@ export default function Settings() {
             className={`rounded-xl px-4 py-2 text-sm ${
               theme === "light"
                 ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
-                : "border border-zinc-200 hover:bg-zinc-100 dark:border-zinc-800 dark:hover:bg-zinc-800"
+                : "border border-zinc-200 hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
             }`}
           >
             Light
@@ -42,7 +42,7 @@ export default function Settings() {
             className={`rounded-xl px-4 py-2 text-sm ${
               theme === "dark"
                 ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
-                : "border border-zinc-200 hover:bg-zinc-100 dark:border-zinc-800 dark:hover:bg-zinc-800"
+                : "border border-zinc-200 hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
             }`}
           >
             Dark


### PR DESCRIPTION
## 概要
  Dark テーマの黒さを弱めるため、背景・カード面・ボーダーのトーンを zinc-900/800/700 寄りに調整しました。Light/
  Dark 切り替えと永続化ロジックには手を入れていません。
## 変更内容
- [ ] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [x] Other:

  - ページ背景を緩和
      - src/index.css:14 の dark:bg-zinc-950 を dark:bg-zinc-900 に変更。
  - ヘッダ背景と区切り線を緩和
      - src/components/Layout.tsx:9 の dark ヘッダ背景を dark:bg-zinc-900/70、ボーダーを dark:border-zinc-700/60
        に変更。
      - src/components/Layout.tsx:27
      - src/components/Layout.tsx:37
      - dark hover を dark:hover:bg-zinc-800 に変更。
  - カード面を背景より1段明るく
      - src/pages/Home.tsx:116
      - src/pages/Home.tsx:134
      - src/pages/Home.tsx:195
      - src/pages/Home.tsx:203
      - src/pages/Home.tsx:245
      - src/pages/Detail.tsx:95
      - src/pages/Detail.tsx:106
      - src/pages/Settings.tsx:23
      - 上記の dark 背景を dark:bg-zinc-800 系へ調整。
  - ボーダーを少し見えやすく
      - Home/Detail/Settings の主要コンテナ・フォーム・入力の dark border を dark:border-zinc-700 に統一。
  - 入力欄の暗色面を重すぎないトーンへ
      - src/pages/Home.tsx:147
      - src/pages/Home.tsx:256
      - src/pages/Home.tsx:266
      - src/pages/Home.tsx:277
      - src/pages/Home.tsx:288
      - src/pages/Detail.tsx:163
      - src/pages/Detail.tsx:173
      - src/pages/Detail.tsx:184
      - src/pages/Detail.tsx:195
      - dark 入力背景を dark:bg-zinc-900 に変更。

## 検証方法
  1. 実行済み: npm run build（成功）
  2. npm run dev
  3. Settings で Dark を選択し、以下を確認
  4. ページ背景が真っ黒寄りではなく濃いグレー寄りになっている
  5. カード背景がページ背景より1段明るく見える
  6. ボーダー/区切り線が判別しやすい
  7. Light に戻して見た目が大きく崩れていない
  8. テーマ切り替えとリロード後の保持が従来どおり動く（既存ロジック維持）

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
      - Dark テーマの最小トーン調整（背景・カード・ボーダー中心）
- スコープ外:
      - ダークテーマ全面再設計
      - アクセントカラー刷新などの大幅配色変更
      - 依存追加
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - 一部コンポーネントの dark hover トーンも合わせて変更しているため、従来よりやや明るめに感じる可能性がありま
    す。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要なら、実機確認後に zinc-800 と zinc-700 の境界（特にボタン hover）を微調整できます。

## 未解決の質問
- 
