### PR TITLE
pseudo Premium Plan

### DIFF
--- a/src/data/entitlement.ts
+++ b/src/data/entitlement.ts
@@ -1,0 +1,76 @@
+export type EntitlementPlan = "free" | "premium";
+export type EntitlementSource = "local" | "prompt" | "stripe";
+
+export type Entitlement = {
+  plan: EntitlementPlan;
+  expiresAt: number | null;
+  source: EntitlementSource;
+  updatedAt: number;
+};
+
+export const ENTITLEMENT_STORAGE_KEY = "trailboard.entitlement.v1";
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+function isPlan(value: unknown): value is EntitlementPlan {
+  return value === "free" || value === "premium";
+}
+
+function isSource(value: unknown): value is EntitlementSource {
+  return value === "local" || value === "prompt" || value === "stripe";
+}
+
+function isEntitlement(value: unknown): value is Entitlement {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<Entitlement>;
+
+  return (
+    isPlan(candidate.plan) &&
+    (candidate.expiresAt === null ||
+      (typeof candidate.expiresAt === "number" &&
+        Number.isFinite(candidate.expiresAt))) &&
+    isSource(candidate.source) &&
+    typeof candidate.updatedAt === "number" &&
+    Number.isFinite(candidate.updatedAt)
+  );
+}
+
+export function createFreeEntitlement(now = Date.now()): Entitlement {
+  return {
+    plan: "free",
+    expiresAt: null,
+    source: "local",
+    updatedAt: now,
+  };
+}
+
+export function loadEntitlement(): Entitlement {
+  const raw = localStorage.getItem(ENTITLEMENT_STORAGE_KEY);
+  if (!raw) return createFreeEntitlement();
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (isEntitlement(parsed)) return parsed;
+    return createFreeEntitlement();
+  } catch {
+    return createFreeEntitlement();
+  }
+}
+
+export function saveEntitlement(entitlement: Entitlement) {
+  localStorage.setItem(ENTITLEMENT_STORAGE_KEY, JSON.stringify(entitlement));
+}
+
+export function isPremiumActive(entitlement: Entitlement, now = Date.now()) {
+  if (entitlement.plan !== "premium") return false;
+  if (entitlement.expiresAt === null) return true;
+  return entitlement.expiresAt > now;
+}
+
+export function createLocalPremiumEntitlement(days: number, now = Date.now()) {
+  return {
+    plan: "premium",
+    expiresAt: now + days * ONE_DAY_MS,
+    source: "local",
+    updatedAt: now,
+  } satisfies Entitlement;
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
+import {
+  createFreeEntitlement,
+  createLocalPremiumEntitlement,
+  isPremiumActive,
+  loadEntitlement,
+  saveEntitlement,
+} from "../data/entitlement";
 
 type Theme = "light" | "dark";
 const THEME_STORAGE_KEY = "trailboard.theme";
@@ -10,6 +17,16 @@ export default function Settings() {
   }, []);
 
   const [theme, setTheme] = useState<Theme>(initial);
+  const [entitlement, setEntitlement] = useState(() => loadEntitlement());
+
+  const premiumActive = useMemo(
+    () => isPremiumActive(entitlement),
+    [entitlement]
+  );
+  const expiresAtLabel = useMemo(() => {
+    if (entitlement.expiresAt === null) return "No expiry";
+    return new Date(entitlement.expiresAt).toLocaleDateString();
+  }, [entitlement.expiresAt]);
 
   useEffect(() => {
     const html = document.documentElement;
@@ -17,6 +34,18 @@ export default function Settings() {
     else html.classList.remove("dark");
     localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
+
+  useEffect(() => {
+    saveEntitlement(entitlement);
+  }, [entitlement]);
+
+  function handleActivatePremium() {
+    setEntitlement(createLocalPremiumEntitlement(30));
+  }
+
+  function handleResetToFree() {
+    setEntitlement(createFreeEntitlement());
+  }
 
   return (
     <div className="space-y-6">
@@ -46,6 +75,57 @@ export default function Settings() {
             }`}
           >
             Dark
+          </button>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
+        <h2 className="text-xl font-semibold">Premium</h2>
+        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+          Entitlement status (local mock)
+        </p>
+
+        <div className="mt-4 grid gap-2 text-sm">
+          <div className="flex items-center gap-2">
+            <span className="text-zinc-500 dark:text-zinc-400">Status:</span>
+            <span
+              className={
+                premiumActive
+                  ? "font-medium text-emerald-700 dark:text-emerald-300"
+                  : "font-medium text-zinc-700 dark:text-zinc-200"
+              }
+            >
+              {premiumActive ? "Active" : "Inactive"}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-zinc-500 dark:text-zinc-400">Plan:</span>
+            <span className="font-medium">{entitlement.plan}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-zinc-500 dark:text-zinc-400">Expires:</span>
+            <span className="font-medium">{expiresAtLabel}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-zinc-500 dark:text-zinc-400">Source:</span>
+            <span className="font-medium">{entitlement.source}</span>
+          </div>
+        </div>
+
+        <div className="mt-5 flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={handleActivatePremium}
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+          >
+            Activate Premium (+30 days)
+          </button>
+          <button
+            type="button"
+            onClick={handleResetToFree}
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+          >
+            Reset to Free
           </button>
         </div>
       </section>


### PR DESCRIPTION
## 概要
  Settings に Premium（Entitlement）セクションを追加し、localStorage 永続化付きの擬似 Premium 付与基盤を実装しま
  した。将来の Stripe/API 差し替えを見据えて、判定ロジックと保存ロジックを src/data/entitlement.ts に分離してい
  ます。

## 変更内容
- [ ] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [x] Other:

  - src/data/entitlement.ts を新規追加
  - ENTITLEMENT_STORAGE_KEY = "trailboard.entitlement.v1" を追加
  - Entitlement 型を追加（plan, expiresAt, source, updatedAt）
  - loadEntitlement / saveEntitlement を実装（JSON文字列で保存・復元）
  - isPremiumActive を実装
      - plan === "premium" かつ expiresAt が未来（または null）で有効
  - createLocalPremiumEntitlement(30) を実装
      - 押下時に plan="premium", expiresAt=now+30days, source="local", updatedAt=now
  - src/pages/Settings.tsx を更新
      - Premium セクション追加
      - 表示: Status（Active/Inactive）, Plan, Expires, Source
      - 操作: Activate Premium (+30 days)、Reset to Free
      - state 変更時に localStorage へ即時保存
      - 既存テーマ切替・永続化ロジックは維持

## 検証方法
  1. npm run build

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
      - Premium 状態表示
      - 擬似付与（+30日）
      - localStorage 永続化と復元
      - Premium 判定ロジックの分離
- スコープ外:
      - Stripe/Webhook/バックエンド
      - 認証や端末間同期
      - Premium 限定機能
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - Activate Premium (+30 days) は毎回「現在時刻+30日」で上書きします（既存期限への加算ではない）。
  - 日付表示は toLocaleDateString() のため表示形式は実行環境依存です。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要なら次段で getEntitlement() を API 実装に差し替えるだけで UI 流用できます。
  - 必要なら「延長時は既存期限に加算」へ変更可能です。

## 未解決の質問
- 
