### PR TITLE
introduce data export/import

### DIFF
--- a/src/data/appState.ts
+++ b/src/data/appState.ts
@@ -1,0 +1,112 @@
+import {
+  type Entitlement,
+  saveEntitlement,
+} from "./entitlement";
+import {
+  getPreferredTrails,
+  saveTrails,
+  type Trail,
+} from "./trails";
+
+export const THEME_STORAGE_KEY = "trailboard.theme";
+
+export type AppDataSnapshot = {
+  version: number;
+  exportedAt: number;
+  cards: Trail[];
+  theme: "light" | "dark";
+  entitlement: Entitlement;
+};
+
+function isTrail(value: unknown): value is Trail {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<Trail>;
+
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.title === "string" &&
+    typeof candidate.subtitle === "string" &&
+    Array.isArray(candidate.tags) &&
+    candidate.tags.every((tag) => typeof tag === "string") &&
+    typeof candidate.minutes === "number"
+  );
+}
+
+function isTheme(value: unknown): value is "light" | "dark" {
+  return value === "light" || value === "dark";
+}
+
+function isEntitlement(value: unknown): value is Entitlement {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<Entitlement>;
+
+  const isPlan = candidate.plan === "free" || candidate.plan === "premium";
+  const isSource =
+    candidate.source === "local" ||
+    candidate.source === "prompt" ||
+    candidate.source === "stripe";
+  const isExpiresAt =
+    candidate.expiresAt === null ||
+    (typeof candidate.expiresAt === "number" &&
+      Number.isFinite(candidate.expiresAt));
+  const isUpdatedAt =
+    typeof candidate.updatedAt === "number" && Number.isFinite(candidate.updatedAt);
+
+  return isPlan && isSource && isExpiresAt && isUpdatedAt;
+}
+
+export function dumpAppState(params: {
+  theme: "light" | "dark";
+  entitlement: Entitlement;
+}): AppDataSnapshot {
+  return {
+    version: 1,
+    exportedAt: Date.now(),
+    cards: getPreferredTrails(),
+    theme: params.theme,
+    entitlement: params.entitlement,
+  };
+}
+
+export function parseAppStateSnapshot(raw: string): AppDataSnapshot {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("Invalid JSON.");
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Invalid data format.");
+  }
+
+  const candidate = parsed as Partial<AppDataSnapshot>;
+  const { version, exportedAt, cards, theme, entitlement } = candidate;
+  const hasValidHeader =
+    typeof version === "number" &&
+    Number.isFinite(version) &&
+    typeof exportedAt === "number" &&
+    Number.isFinite(exportedAt);
+  const hasValidCards = Array.isArray(cards) && cards.every(isTrail);
+  const hasValidTheme = isTheme(theme);
+  const hasValidEntitlement = isEntitlement(entitlement);
+
+  if (!hasValidHeader || !hasValidCards || !hasValidTheme || !hasValidEntitlement) {
+    throw new Error("Invalid backup schema.");
+  }
+
+  return {
+    version,
+    exportedAt,
+    cards,
+    theme,
+    entitlement,
+  };
+}
+
+export function restoreAppState(snapshot: AppDataSnapshot) {
+  saveTrails(snapshot.cards);
+  localStorage.setItem(THEME_STORAGE_KEY, snapshot.theme);
+  saveEntitlement(snapshot.entitlement);
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  dumpAppState,
+  parseAppStateSnapshot,
+  restoreAppState,
+  THEME_STORAGE_KEY,
+} from "../data/appState";
+import {
   createFreeEntitlement,
   createLocalPremiumEntitlement,
   isPremiumActive,
@@ -8,7 +14,6 @@ import {
 } from "../data/entitlement";
 
 type Theme = "light" | "dark";
-const THEME_STORAGE_KEY = "trailboard.theme";
 
 export default function Settings() {
   const initial = useMemo<Theme>(() => {
@@ -18,6 +23,9 @@ export default function Settings() {
 
   const [theme, setTheme] = useState<Theme>(initial);
   const [entitlement, setEntitlement] = useState(() => loadEntitlement());
+  const [exportJson, setExportJson] = useState("");
+  const [importJson, setImportJson] = useState("");
+  const [dataError, setDataError] = useState<string | null>(null);
 
   const premiumActive = useMemo(
     () => isPremiumActive(entitlement),
@@ -45,6 +53,29 @@ export default function Settings() {
 
   function handleResetToFree() {
     setEntitlement(createFreeEntitlement());
+  }
+
+  function handleExportJson() {
+    const snapshot = dumpAppState({ theme, entitlement });
+    setExportJson(JSON.stringify(snapshot, null, 2));
+    setDataError(null);
+  }
+
+  function handleImportJson() {
+    const confirmed = window.confirm(
+      "Import will overwrite current local data. Continue?"
+    );
+    if (!confirmed) return;
+
+    try {
+      const snapshot = parseAppStateSnapshot(importJson);
+      restoreAppState(snapshot);
+      window.location.reload();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to import data.";
+      setDataError(message);
+    }
   }
 
   return (
@@ -127,6 +158,48 @@ export default function Settings() {
           >
             Reset to Free
           </button>
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
+        <h2 className="text-xl font-semibold">Data</h2>
+        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+          Export / Import local backup JSON
+        </p>
+
+        <div className="mt-4 space-y-3">
+          <button
+            type="button"
+            onClick={handleExportJson}
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+          >
+            Export JSON
+          </button>
+          <textarea
+            value={exportJson}
+            readOnly
+            placeholder="Exported JSON will appear here."
+            className="min-h-36 w-full rounded-2xl border border-zinc-200 bg-white px-3 py-2 text-xs outline-none dark:border-zinc-700 dark:bg-zinc-900"
+          />
+        </div>
+
+        <div className="mt-5 space-y-3">
+          <textarea
+            value={importJson}
+            onChange={(event) => setImportJson(event.target.value)}
+            placeholder="Paste backup JSON to import (overwrite)."
+            className="min-h-36 w-full rounded-2xl border border-zinc-200 bg-white px-3 py-2 text-xs outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+          />
+          <button
+            type="button"
+            onClick={handleImportJson}
+            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+          >
+            Import JSON
+          </button>
+          {dataError && (
+            <p className="text-sm text-red-600 dark:text-red-400">{dataError}</p>
+          )}
         </div>
       </section>
     </div>


### PR DESCRIPTION
## 概要
  Settings に Data (Export/Import) セクションを追加し、ローカル状態（cards/theme/entitlement）を JSON でバック
  アップ/復元できるようにしました。復元は localStorage への全置換方式で、確認ダイアログ・エラーハンドリング付き
  です。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [x] Other:

  - src/data/appState.ts を追加
  - dumpAppState() を実装
  - 出力 JSON に version と exportedAt を含める
  - cards / theme / entitlement をまとめて出力
  - parseAppStateSnapshot() を実装
  - JSON パース不可・形式不正時に例外化（破壊的更新前に停止）
  - restoreAppState() を実装
  - cards / theme / entitlement を localStorage へ反映
  - src/pages/Settings.tsx を更新
  - Data セクションを追加
  - Export JSON ボタン追加（テキストエリアへ JSON 表示）
  - Import 用テキストエリアと Import JSON ボタン追加
  - Import 前に window.confirm を追加
  - Import 成功後 window.location.reload() で確実反映
  - Import 失敗時にエラー文言表示（クラッシュ防止）

## 検証方法
  1. npm run build

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
      - Settings での手動バックアップ/復元（JSON）
      - localStorage 主要キーのエクスポート/インポート
- スコープ外:
      - 差分マージ、暗号化、同期、詳細スキーマ管理、Undo/Redo
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - Import は全置換なので、誤った JSON を取り込むと既存ローカル状態が置き換わります（確認ダイアログあり）。
  - Import 後にリロードするため、実行中の画面状態は再初期化されます。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 将来キーが増えた場合は src/data/appState.ts の snapshot 対象に追加するだけで拡張できます。

## 未解決の質問
- 
