### PR TITLE
resolve redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ chmod +x scripts/publish_commit.sh
 
 ## Github Pages(CD)
  - CDを実装し、push、mergeされた反映は下記のリンクから参照可能。
+ - ルーティングは HashRouter 方式のため、URL は `.../Trailboard/#/` 形式になります。
 
- - [Trailboard](https://airship10may.github.io/Trailboard/)
+ - [Trailboard](https://airship10may.github.io/Trailboard/#/)
 
 
 ## 参照先

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
 
@@ -15,8 +15,8 @@ if (savedTheme === "dark") {
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## 概要
  BrowserRouter を HashRouter に切り替え、GitHub Pages の深いURL（/trail/:id）でもリロード/直アクセス時に 404 に
  ならない構成にしました。URL は .../Trailboard/#/... 形式になります。

## 変更内容
- [ ] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [x] Other:

  - src/main.tsx:3
      - BrowserRouter を HashRouter に変更。
  - src/main.tsx:18
      - ルートラッパーを <HashRouter> に変更。
  - README.md:115
      - GitHub Pages のURL形式が #/ ベースになった旨を追記。
  - README.md:117
      - 公開リンクを https://airship10may.github.io/Trailboard/#/ に更新。

## 検証方法
  1. npm run build

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
  - ルーティング方式の変更（BrowserRouter → HashRouter）
  - READMEの運用メモ更新
- スコープ外:
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - 既存の外部共有リンクが #/ なしの場合、期待ルートを直接指さなくなります（今後は #/... 形式を共有する必要あ
    り）。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  1. GitHub Pages 配備後に .../Trailboard/#/trail/<id> のリロード/直アクセスを実機で確認。

## 未解決の質問
- 
