### PR TITLE
fix premium plan modal

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -52,6 +52,7 @@ export default function Settings() {
     return new Date(entitlement.expiresAt).toLocaleDateString();
   }, [entitlement.expiresAt]);
   const latestPromptSubmission = promptSubmissions[0] ?? null;
+  const isActivateDisabled = premiumActive;
 
   useEffect(() => {
     const html = document.documentElement;
@@ -97,6 +98,7 @@ export default function Settings() {
   }
 
   function openActivateModal() {
+    if (isActivateDisabled) return;
     setPendingPremiumAction("activate");
     setShowPromptRoute(false);
     setPromptAnswer("");
@@ -230,10 +232,17 @@ export default function Settings() {
         <div className="mt-5 flex flex-wrap gap-3">
           <button
             type="button"
+            disabled={isActivateDisabled}
             onClick={openActivateModal}
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm transition-colors hover:border-amber-200 hover:bg-amber-50 hover:text-amber-800 dark:border-zinc-700 dark:hover:border-amber-900/70 dark:hover:bg-amber-950/40 dark:hover:text-amber-300"
+            className={`rounded-xl border px-4 py-2 text-sm transition-colors ${
+              isActivateDisabled
+                ? "cursor-not-allowed border-amber-200 bg-amber-50 text-amber-800/80 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-300/80"
+                : "border-zinc-200 hover:border-amber-200 hover:bg-amber-50 hover:text-amber-800 dark:border-zinc-700 dark:hover:border-amber-900/70 dark:hover:bg-amber-950/40 dark:hover:text-amber-300"
+            }`}
           >
-            Activate Premium (+30 days)
+            {isActivateDisabled
+              ? "Premium Active (+30 days locked)"
+              : "Activate Premium (+30 days)"}
           </button>
           <button
             type="button"
@@ -316,8 +325,14 @@ export default function Settings() {
       </section>
 
       {pendingPremiumAction && (
-        <div className="fixed inset-0 z-40 flex items-end justify-center bg-zinc-950/45 p-4 sm:items-center">
-          <div className="w-full max-w-md rounded-3xl border border-zinc-200 bg-white p-5 shadow-lg dark:border-zinc-700 dark:bg-zinc-800">
+        <div
+          className="fixed inset-0 z-40 flex items-end justify-center bg-zinc-950/45 p-4 sm:items-center"
+          onClick={closePremiumModal}
+        >
+          <div
+            className="w-full max-w-md rounded-3xl border border-zinc-200 bg-white p-5 shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
+            onClick={(event) => event.stopPropagation()}
+          >
             {pendingPremiumAction === "activate" ? (
               <>
                 <h3 className="text-base font-semibold">Activate Premium</h3>
@@ -377,6 +392,16 @@ export default function Settings() {
                     </div>
                   </div>
                 )}
+
+                <div className="mt-4 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={closePremiumModal}
+                    className="rounded-xl px-3 py-2 text-xs text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                  >
+                    Close
+                  </button>
+                </div>
               </>
             ) : (
               <>
@@ -402,16 +427,6 @@ export default function Settings() {
                 </div>
               </>
             )}
-
-            <div className="mt-4 flex justify-end">
-              <button
-                type="button"
-                onClick={closePremiumModal}
-                className="rounded-xl px-3 py-2 text-xs text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-700"
-              >
-                Close
-              </button>
-            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## 概要
  Premium が Active の間は Activate Premium (+30 days) を押せないようにし、見た目でも「有効中」を判別できるよう
  にしました。あわせてモーダルの役割を整理し、confirm 相当では Cancel/Confirm のみ、choice 相当では Close のみに
  なるように分離しました。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/pages/Settings.tsx:55
      - isActivateDisabled を追加（premiumActive を利用）。
  - src/pages/Settings.tsx:100
      - openActivateModal で isActivateDisabled 時は早期 return（モーダルを開かない）。
  - src/pages/Settings.tsx:234
      - Activate ボタンを disabled 化し、Active 時の専用スタイルを追加。
      - ラベルを Active 時に Premium Active (+30 days locked) に変更。
      - cursor-not-allowed + 薄ゴールド系で「有効中」を視覚化。
  - src/pages/Settings.tsx:327
      - モーダルのオーバーレイクリックで閉じる挙動を追加（Cancel 扱い）。
      - 内部クリックは stopPropagation。
  - src/pages/Settings.tsx:392
      - activate（choice）モーダルにのみ Close を表示。
  - src/pages/Settings.tsx:404
      - reset（confirm）モーダルは Cancel/Confirm のみを維持。
      - 共通 Close を削除し、重複を解消。

## 検証方法
  1. npm run lint
  2. npm run build

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
      - Active 時 Activate 無効化と視覚表現
      - モーダルの役割分離（choice/confirm）
- スコープ外:
      - Premium 延長機能（Extend）
      - 決済連携やバックエンド対応
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - Activate ボタン文言を状態依存で変更しているため、文言固定運用が必要な場合は調整が必要です。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
- 

## 未解決の質問
- 
