### PR TITLE
arrange max card limit

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,18 +9,27 @@ import {
   saveTrails,
 } from "../data/trails";
 import type { Trail } from "../data/trails";
+import { isPremiumActive, loadEntitlement } from "../data/entitlement";
+
+const FREE_CARD_LIMIT = 10;
 
 export default function Home() {
   const nav = useNavigate();
   const [query, setQuery] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [items, setItems] = useState<Trail[]>(() => getPreferredTrails());
+  const [entitlement] = useState(() => loadEntitlement());
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [titleInput, setTitleInput] = useState("");
   const [descriptionInput, setDescriptionInput] = useState("");
   const [tagsInput, setTagsInput] = useState("");
   const [durationInput, setDurationInput] = useState("");
   const [formError, setFormError] = useState<string | null>(null);
+  const premiumActive = useMemo(
+    () => isPremiumActive(entitlement),
+    [entitlement]
+  );
+  const isCreateLimitReached = !premiumActive && items.length >= FREE_CARD_LIMIT;
 
   const tagSummaries = useMemo(() => {
     const counts = new Map<string, number>();
@@ -78,12 +87,20 @@ export default function Home() {
   }
 
   function handleOpenModal() {
+    if (isCreateLimitReached) return;
     resetForm();
     setIsModalOpen(true);
   }
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+
+    if (isCreateLimitReached) {
+      setFormError(
+        `Free plan can create up to ${FREE_CARD_LIMIT} cards. Upgrade to Premium to add more.`
+      );
+      return;
+    }
 
     const title = titleInput.trim();
     if (!title) {
@@ -124,11 +141,22 @@ export default function Home() {
           <button
             type="button"
             onClick={handleOpenModal}
-            className="shrink-0 rounded-xl bg-zinc-900 px-3 py-2 text-sm text-white hover:opacity-90 dark:bg-zinc-100 dark:text-zinc-900"
+            disabled={isCreateLimitReached}
+            className={`shrink-0 rounded-xl px-3 py-2 text-sm ${
+              isCreateLimitReached
+                ? "cursor-not-allowed bg-zinc-300 text-zinc-600 dark:bg-zinc-600 dark:text-zinc-300"
+                : "bg-zinc-900 text-white hover:opacity-90 dark:bg-zinc-100 dark:text-zinc-900"
+            }`}
           >
             + New
           </button>
         </div>
+        {isCreateLimitReached && (
+          <p className="mt-3 text-sm text-amber-700 dark:text-amber-300">
+            Free plan limit reached ({FREE_CARD_LIMIT} cards). Upgrade to Premium
+            to create more cards.
+          </p>
+        )}
       </section>
 
       <section className="rounded-3xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">


### PR DESCRIPTION
## 概要
  Freeユーザーにカード作成上限（10枚）を導入し、Premium（entitlement active）では無制限のまま作成できるようにし
  ました。Premium差別化を最小変更で追加するため、既存の entitlement 判定ロジックを Home に適用しています。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [x] Other:

  - src/pages/Home.tsx に FREE_CARD_LIMIT = 10 を追加。
  - src/pages/Home.tsx で既存の loadEntitlement / isPremiumActive を利用し、Free かつカード総数10枚以上を
    isCreateLimitReached として判定。
  - src/pages/Home.tsx の + New ボタンを制限時に disabled 化し、見た目を制限状態に変更。
  - src/pages/Home.tsx に上限到達理由のメッセージを表示。
  - src/pages/Home.tsx の handleOpenModal / handleSubmit に上限ガードを追加し、制限時は新規作成フローに入れない
    ようにした。

## 検証方法
  1. npm run build
  2. Free状態（Settingsで entitlement inactive）でカードを10枚以上にすると、Home の + New が disabled になり、上
     限メッセージが表示されることを確認。
  3. Premium状態（Settingsで entitlement active）では、+ New から枚数制限なくカード作成できることを確認。
  4. 既存の編集/削除/検索/タグフィルタ、localStorage永続が従来どおり動くことを確認。

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内: Free/Premium によるカード新規作成上限の導入（UI制限と理由表示含む）。
- スコープ外: サーバ同期、複数端末共有、Settingsでの上限可変化、自動削除/圧縮、その他Premium機能追加。
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - Home画面での entitlement は画面初期化時に読み込むため、同一画面に留まったまま外部で entitlement が変わるケー
    スには追従しません（通常の画面遷移運用では問題なし）。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要なら FREE_CARD_LIMIT を共通定数ファイルへ切り出し、将来のプラン別制御を拡張しやすくできます。

## 未解決の質問
- 
