### PR TITLE
refine premium theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,13 @@
 
 :root {
   color-scheme: light;
+  --tb-page-bg: #fafafa;
+  --tb-surface-bg: #ffffff;
+  --tb-text: #18181b;
+  --tb-muted: #52525b;
+  --tb-border: #e4e4e7;
+  --tb-input-bg: #ffffff;
+  --tb-placeholder: #71717a;
 }
 
 html.dark {
@@ -16,81 +23,75 @@ body {
 
 html[data-theme="soft-dark"] {
   color-scheme: dark;
-}
-
-html[data-theme="soft-dark"] body {
-  background: #141922;
-  color: #e5e7eb;
-}
-
-html[data-theme="soft-dark"] [class*="bg-white"] {
-  background-color: #1f2633 !important;
-}
-
-html[data-theme="soft-dark"] [class*="border-zinc-200"] {
-  border-color: #3c4658 !important;
-}
-
-html[data-theme="soft-dark"] [class*="text-zinc-900"] {
-  color: #f3f4f6 !important;
-}
-
-html[data-theme="soft-dark"] [class*="text-zinc-700"],
-html[data-theme="soft-dark"] [class*="text-zinc-600"],
-html[data-theme="soft-dark"] [class*="text-zinc-500"] {
-  color: #cbd5e1 !important;
+  --tb-page-bg: #141a24;
+  --tb-surface-bg: #1f2835;
+  --tb-text: #eff3f8;
+  --tb-muted: #c3cddb;
+  --tb-border: #445367;
+  --tb-input-bg: #1b2430;
+  --tb-placeholder: #9ba9bc;
 }
 
 html[data-theme="ivory"] {
   color-scheme: light;
-}
-
-html[data-theme="ivory"] body {
-  background: #f5efe3;
-  color: #2f2a23;
-}
-
-html[data-theme="ivory"] [class*="bg-white"] {
-  background-color: #fffaf1 !important;
-}
-
-html[data-theme="ivory"] [class*="border-zinc-200"] {
-  border-color: #d6c6a4 !important;
-}
-
-html[data-theme="ivory"] [class*="text-zinc-900"] {
-  color: #2f2a23 !important;
-}
-
-html[data-theme="ivory"] [class*="text-zinc-700"],
-html[data-theme="ivory"] [class*="text-zinc-600"],
-html[data-theme="ivory"] [class*="text-zinc-500"] {
-  color: #6f6353 !important;
+  --tb-page-bg: #f5eedf;
+  --tb-surface-bg: #fffaf0;
+  --tb-text: #2f2a22;
+  --tb-muted: #6f6453;
+  --tb-border: #d5c4a2;
+  --tb-input-bg: #fff6e9;
+  --tb-placeholder: #8a7c64;
 }
 
 html[data-theme="ash-grey"] {
   color-scheme: light;
+  --tb-page-bg: #e8ecef;
+  --tb-surface-bg: #f6f8fa;
+  --tb-text: #20262d;
+  --tb-muted: #55616c;
+  --tb-border: #b6bec8;
+  --tb-input-bg: #f1f4f7;
+  --tb-placeholder: #6d7783;
 }
 
-html[data-theme="ash-grey"] body {
-  background: #e8ebee;
-  color: #202327;
+html[data-theme] body {
+  background: var(--tb-page-bg);
+  color: var(--tb-text);
 }
 
-html[data-theme="ash-grey"] [class*="bg-white"] {
-  background-color: #f5f7f8 !important;
+html[data-theme] [class*="bg-white"] {
+  background-color: var(--tb-surface-bg) !important;
 }
 
-html[data-theme="ash-grey"] [class*="border-zinc-200"] {
-  border-color: #b5bcc4 !important;
+html[data-theme] [class*="border-zinc-200"],
+html[data-theme] [class*="border-zinc-700"] {
+  border-color: var(--tb-border) !important;
 }
 
-html[data-theme="ash-grey"] [class*="text-zinc-900"] {
-  color: #202327 !important;
+html[data-theme] [class*="text-zinc-100"],
+html[data-theme] [class*="text-zinc-200"],
+html[data-theme] [class*="text-zinc-300"],
+html[data-theme] [class*="text-zinc-800"],
+html[data-theme] [class*="text-zinc-900"] {
+  color: var(--tb-text) !important;
 }
 
-html[data-theme="ash-grey"] [class*="text-zinc-700"],
-html[data-theme="ash-grey"] [class*="text-zinc-600"],
-html[data-theme="ash-grey"] [class*="text-zinc-500"] {
-  color: #505962 !important;
+html[data-theme] [class*="text-zinc-400"],
+html[data-theme] [class*="text-zinc-500"],
+html[data-theme] [class*="text-zinc-600"],
+html[data-theme] [class*="text-zinc-700"] {
+  color: var(--tb-muted) !important;
+}
+
+html[data-theme] input,
+html[data-theme] textarea,
+html[data-theme] select {
+  background-color: var(--tb-input-bg) !important;
+  color: var(--tb-text) !important;
+  border-color: var(--tb-border) !important;
+}
+
+html[data-theme] input::placeholder,
+html[data-theme] textarea::placeholder {
+  color: var(--tb-placeholder) !important;
 }


### PR DESCRIPTION
## 概要
  Premiumテーマ（Soft Dark / Ivory / Ash Grey）の可読性崩れを、data-theme + CSS変数トークンで一括修正しました。
  背景だけでなく文字・補助文字・ボーダー・入力欄・placeholderを同一仕組みで制御し、3テーマ共通で読みやすさを改善
  しています。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/index.css:5 にテーマトークンを追加。
      - --tb-page-bg / --tb-surface-bg / --tb-text / --tb-muted / --tb-border / --tb-input-bg / --tb-placeholder
  - src/index.css:24 以降で soft-dark / ivory / ash-grey ごとのトークン値を定義。
  - src/index.css:57 以降で html[data-theme] 共通ルールを追加し、既存Tailwindクラスに対してトークンを反映。
      - ページ背景、カード背景、主要文字、サブ文字、ボーダー色を統一適用
      - input / textarea / select の文字色・背景色・枠線を適用
      - placeholder色を適用
  - 以前の「テーマごとの個別上書き3セット」を削除し、共通化。

## 検証方法
  1. npm run lint
  2. npm run build
  3. Settingsで Soft Dark / Ivory / Ash Grey を選択し、以下が可読であることを確認
      - 見出し、本文、サブテキスト
      - ボタンラベル（選択/非選択/disabled）
      - 入力欄とplaceholder（Search含む）
  4. Light / Dark で表示崩れがないことを確認
  5. Premiumテーマ選択後に Free に戻して、フォールバックが崩れないことを確認

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
  - Premium 3テーマの可読性改善
  - テーマ適用CSSの共通トークン化
- スコープ外:
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - html[data-theme] [class*="..."] のクラス部分一致セレクタに依存しているため、将来クラス命名が大きく変わると調
    整が必要です。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要なら次段で、主要コンポーネントに専用ユーティリティクラスを付与して、部分一致セレクタ依存を減らせます。

## 未解決の質問
- 
