### PR TITLE
fix premium theme

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -27,6 +27,13 @@ import {
 type PremiumActionType = "activate" | "reset";
 
 const PROMPT_QUESTION = "人生であった一番甘酸っぱい瞬間は？";
+const sectionClass =
+  "rounded-3xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] p-6 shadow-sm";
+const mutedTextClass = "text-[var(--tb-muted)]";
+const buttonClass =
+  "rounded-xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] px-4 py-2 text-sm text-[var(--tb-text)] transition hover:opacity-90";
+const textAreaClass =
+  "w-full rounded-2xl border border-[var(--tb-border)] bg-[var(--tb-input-bg)] px-3 py-2 text-sm text-[var(--tb-text)] outline-none placeholder:text-[var(--tb-placeholder)] focus:border-[var(--tb-border)] focus:ring-2 focus:ring-[var(--tb-border)]/50";
 
 export default function Settings() {
   const initialEntitlement = useMemo(() => loadEntitlement(), []);
@@ -170,9 +177,9 @@ export default function Settings() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
+      <section className={sectionClass}>
         <h1 className="text-xl font-semibold">Settings</h1>
-        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+        <p className={`mt-1 text-sm ${mutedTextClass}`}>
           Select app theme (Premium unlocks additional variations)
         </p>
 
@@ -189,10 +196,10 @@ export default function Settings() {
                 onClick={() => setTheme(option.value)}
                 className={`rounded-xl px-4 py-2 text-sm ${
                   isSelected
-                    ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                    ? "border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] font-semibold text-[var(--tb-text)] ring-2 ring-[var(--tb-border)]"
                     : isLocked
-                      ? "cursor-not-allowed border border-zinc-200 bg-zinc-100 text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400"
-                      : "border border-zinc-200 hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+                      ? "cursor-not-allowed border border-[var(--tb-border)] bg-[var(--tb-input-bg)] text-[var(--tb-muted)] opacity-70"
+                      : "border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] text-[var(--tb-text)] hover:ring-2 hover:ring-[var(--tb-border)]"
                 }`}
               >
                 {option.label}
@@ -202,45 +209,39 @@ export default function Settings() {
           })}
         </div>
         {!premiumActive && (
-          <p className="mt-3 text-sm text-amber-700 dark:text-amber-300">
+          <p className={`mt-3 text-sm ${mutedTextClass}`}>
             Premium themes are locked. Activate Premium to use Soft Dark, Ivory,
             and Ash Grey.
           </p>
         )}
-        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
+        <p className={`mt-2 text-sm ${mutedTextClass}`}>
           Premium theme falls back to Light when entitlement becomes inactive.
         </p>
       </section>
 
-      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
+      <section className={sectionClass}>
         <h2 className="text-xl font-semibold">Premium</h2>
-        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+        <p className={`mt-1 text-sm ${mutedTextClass}`}>
           Entitlement status (local mock)
         </p>
 
         <div className="mt-4 grid gap-2 text-sm">
           <div className="flex items-center gap-2">
-            <span className="text-zinc-500 dark:text-zinc-400">Status:</span>
-            <span
-              className={
-                premiumActive
-                  ? "font-medium text-emerald-700 dark:text-emerald-300"
-                  : "font-medium text-zinc-700 dark:text-zinc-200"
-              }
-            >
+            <span className={mutedTextClass}>Status:</span>
+            <span className="font-medium">
               {premiumActive ? "Active" : "Inactive"}
             </span>
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-zinc-500 dark:text-zinc-400">Plan:</span>
+            <span className={mutedTextClass}>Plan:</span>
             <span className="font-medium">{entitlement.plan}</span>
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-zinc-500 dark:text-zinc-400">Expires:</span>
+            <span className={mutedTextClass}>Expires:</span>
             <span className="font-medium">{expiresAtLabel}</span>
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-zinc-500 dark:text-zinc-400">Source:</span>
+            <span className={mutedTextClass}>Source:</span>
             <span className="font-medium">{entitlement.source}</span>
           </div>
         </div>
@@ -250,10 +251,10 @@ export default function Settings() {
             type="button"
             disabled={isActivateDisabled}
             onClick={openActivateModal}
-            className={`rounded-xl border px-4 py-2 text-sm transition-colors ${
+            className={`rounded-xl border px-4 py-2 text-sm transition ${
               isActivateDisabled
-                ? "cursor-not-allowed border-amber-200 bg-amber-50 text-amber-800/80 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-300/80"
-                : "border-zinc-200 hover:border-amber-200 hover:bg-amber-50 hover:text-amber-800 dark:border-zinc-700 dark:hover:border-amber-900/70 dark:hover:bg-amber-950/40 dark:hover:text-amber-300"
+                ? "cursor-not-allowed border-[var(--tb-border)] bg-[var(--tb-input-bg)] text-[var(--tb-muted)] opacity-70"
+                : "border-[var(--tb-border)] bg-[var(--tb-surface-bg)] text-[var(--tb-text)] hover:ring-2 hover:ring-[var(--tb-border)]"
             }`}
           >
             {isActivateDisabled
@@ -263,26 +264,26 @@ export default function Settings() {
           <button
             type="button"
             onClick={openResetModal}
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm transition-colors hover:border-red-200 hover:bg-red-50 hover:text-red-700 dark:border-zinc-700 dark:hover:border-red-900/70 dark:hover:bg-red-950/40 dark:hover:text-red-300"
+            className={buttonClass}
           >
             Reset to Free
           </button>
         </div>
 
-        <div className="mt-5 rounded-2xl border border-zinc-200 p-4 text-sm dark:border-zinc-700">
+        <div className="mt-5 rounded-2xl border border-[var(--tb-border)] p-4 text-sm">
           <h3 className="font-semibold">Prompt submission history</h3>
           {latestPromptSubmission ? (
             <div className="mt-3 space-y-1">
               <div>
-                <span className="text-zinc-500 dark:text-zinc-400">Prompt: </span>
+                <span className={mutedTextClass}>Prompt: </span>
                 <span>{latestPromptSubmission.promptText}</span>
               </div>
               <div>
-                <span className="text-zinc-500 dark:text-zinc-400">Answer: </span>
+                <span className={mutedTextClass}>Answer: </span>
                 <span>{latestPromptSubmission.answerText}</span>
               </div>
               <div>
-                <span className="text-zinc-500 dark:text-zinc-400">
+                <span className={mutedTextClass}>
                   Submitted: 
                 </span>
                 <span>
@@ -291,16 +292,16 @@ export default function Settings() {
               </div>
             </div>
           ) : (
-            <p className="mt-2 text-zinc-500 dark:text-zinc-400">
+            <p className={`mt-2 ${mutedTextClass}`}>
               No prompt submissions yet.
             </p>
           )}
         </div>
       </section>
 
-      <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
+      <section className={sectionClass}>
         <h2 className="text-xl font-semibold">Data</h2>
-        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+        <p className={`mt-1 text-sm ${mutedTextClass}`}>
           Export / Import local backup JSON
         </p>
 
@@ -308,7 +309,7 @@ export default function Settings() {
           <button
             type="button"
             onClick={handleExportJson}
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+            className={buttonClass}
           >
             Export JSON
           </button>
@@ -316,7 +317,7 @@ export default function Settings() {
             value={exportJson}
             readOnly
             placeholder="Exported JSON will appear here."
-            className="min-h-36 w-full rounded-2xl border border-zinc-200 bg-white px-3 py-2 text-xs outline-none dark:border-zinc-700 dark:bg-zinc-900"
+            className={`min-h-36 text-xs ${textAreaClass}`}
           />
         </div>
 
@@ -325,17 +326,17 @@ export default function Settings() {
             value={importJson}
             onChange={(event) => setImportJson(event.target.value)}
             placeholder="Paste backup JSON to import (overwrite)."
-            className="min-h-36 w-full rounded-2xl border border-zinc-200 bg-white px-3 py-2 text-xs outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+            className={`min-h-36 text-xs ${textAreaClass}`}
           />
           <button
             type="button"
             onClick={handleImportJson}
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+            className={buttonClass}
           >
             Import JSON
           </button>
           {dataError && (
-            <p className="text-sm text-red-600 dark:text-red-400">{dataError}</p>
+            <p className={`text-sm ${mutedTextClass}`}>{dataError}</p>
           )}
         </div>
       </section>
@@ -346,13 +347,13 @@ export default function Settings() {
           onClick={closePremiumModal}
         >
           <div
-            className="w-full max-w-md rounded-3xl border border-zinc-200 bg-white p-5 shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
+            className="w-full max-w-md rounded-3xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] p-5 shadow-lg"
             onClick={(event) => event.stopPropagation()}
           >
             {pendingPremiumAction === "activate" ? (
               <>
                 <h3 className="text-base font-semibold">Activate Premium</h3>
-                <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
+                <p className={`mt-2 text-sm ${mutedTextClass}`}>
                   Premiumは0円/1カ月です。付与方法を選んでください。
                 </p>
 
@@ -361,47 +362,45 @@ export default function Settings() {
                     <button
                       type="button"
                       onClick={handleActivateWithLocalRoute}
-                      className="w-full rounded-xl border border-zinc-200 px-4 py-2 text-left text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+                      className={`w-full text-left ${buttonClass}`}
                     >
                       0円で今月分を有効化する（local / mock）
                     </button>
                     <button
                       type="button"
                       onClick={handleOpenPromptRoute}
-                      className="w-full rounded-xl border border-zinc-200 px-4 py-2 text-left text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+                      className={`w-full text-left ${buttonClass}`}
                     >
                       お題で1ヶ月分を肩代わりする（prompt）
                     </button>
                   </div>
                 ) : (
                   <div className="mt-5 space-y-3">
-                    <div className="rounded-2xl border border-zinc-200 p-3 text-sm dark:border-zinc-700">
-                      <div className="text-zinc-500 dark:text-zinc-400">お題</div>
+                    <div className="rounded-2xl border border-[var(--tb-border)] p-3 text-sm">
+                      <div className={mutedTextClass}>お題</div>
                       <div className="mt-1">{PROMPT_QUESTION}</div>
                     </div>
                     <textarea
                       value={promptAnswer}
                       onChange={(event) => setPromptAnswer(event.target.value)}
                       placeholder="回答を入力してください"
-                      className="min-h-28 w-full rounded-2xl border border-zinc-200 bg-white px-3 py-2 text-sm outline-none focus:border-zinc-400 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:bg-zinc-900 dark:focus:border-zinc-600 dark:focus:ring-zinc-800"
+                      className={`min-h-28 ${textAreaClass}`}
                     />
                     {promptError && (
-                      <p className="text-sm text-red-600 dark:text-red-400">
-                        {promptError}
-                      </p>
+                      <p className={`text-sm ${mutedTextClass}`}>{promptError}</p>
                     )}
                     <div className="flex justify-between gap-2">
                       <button
                         type="button"
                         onClick={() => setShowPromptRoute(false)}
-                        className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+                        className={buttonClass}
                       >
                         Back
                       </button>
                       <button
                         type="button"
                         onClick={handleSubmitPromptRoute}
-                        className="rounded-xl bg-zinc-900 px-4 py-2 text-sm text-white hover:opacity-90 dark:bg-zinc-100 dark:text-zinc-900"
+                        className={buttonClass}
                       >
                         回答して有効化
                       </button>
@@ -413,7 +412,7 @@ export default function Settings() {
                   <button
                     type="button"
                     onClick={closePremiumModal}
-                    className="rounded-xl px-3 py-2 text-xs text-zinc-500 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                    className="rounded-xl px-3 py-2 text-xs text-[var(--tb-muted)] transition hover:bg-[var(--tb-input-bg)]"
                   >
                     Close
                   </button>
@@ -422,21 +421,21 @@ export default function Settings() {
             ) : (
               <>
                 <h3 className="text-base font-semibold">Confirm action</h3>
-                <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
+                <p className={`mt-2 text-sm ${mutedTextClass}`}>
                   Freeに戻します。よろしいですか？
                 </p>
                 <div className="mt-5 flex justify-end gap-2">
                   <button
                     type="button"
                     onClick={closePremiumModal}
-                    className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+                    className={buttonClass}
                   >
                     Cancel
                   </button>
                   <button
                     type="button"
                     onClick={handleConfirmReset}
-                    className="rounded-xl bg-zinc-900 px-4 py-2 text-sm text-white hover:opacity-90 dark:bg-zinc-100 dark:text-zinc-900"
+                    className={buttonClass}
                   >
                     Confirm
                   </button>


### PR DESCRIPTION
## 概要
  Settings の固定色クラス依存を減らし、テーマトークン（--tb-*）参照へ統一しました。特にテーマ選択ボタン群の
  selected / disabled / hover をトークンベースにして、Premiumテーマでも可読性が崩れない状態にしています。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [x] Other:

  - src/pages/Settings.tsx に共通トークンクラスを追加:
      - sectionClass
      - mutedTextClass
      - buttonClass
      - textAreaClass
  - Theme セクションのテーマボタンを固定色からトークン参照へ置換:
      - bg-zinc-900 text-white dark:* を撤去
      - border-[var(--tb-border)] bg-[var(--tb-surface-bg)] text-[var(--tb-text)] ベースへ変更
      - selected は ring と font-semibold で表現
      - disabled は text-[var(--tb-muted)] + opacity で可読性維持
  - Settings ページ内の主要ボタン/入力欄/説明文もトークン参照へ統一（可読性の底上げ）
  - モーダル内の主要ボタン・入力欄も同様にトークン参照へ変更

## 検証方法
  1. npm run lint
  2. npm run build
  3. Settings で Light / Dark / Soft Dark / Ivory / Ash Grey を切り替え、テーマ選択ボタンのラベルが selected /
     non-selected / disabled 全状態で読めることを確認
  4. Settings の見出し・説明文・主要ボタン・入力欄文字/placeholder が各Premiumテーマで読めることを確認
  5. Premiumテーマから Free に戻した時のフォールバック挙動が維持されることを確認

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
  - src/pages/Settings.tsx の参照側クラスをテーマトークン化
  - 可読性改善に直結する UI クラス置換
- スコープ外:
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - モーダル背景オーバーレイ（bg-zinc-950/45）は固定色のままです（可読性には影響しないため維持）。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要なら Home / Detail でも同じ buttonClass 系のトークン参照へ段階的に統一できます。

## 未解決の質問
- 
