### PR TITLE
fix selected button styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,13 @@
 
 html.dark {
   color-scheme: dark;
+  --tb-page-bg: #18181b;
+  --tb-surface-bg: #27272a;
+  --tb-text: #f4f4f5;
+  --tb-muted: #a1a1aa;
+  --tb-border: #3f3f46;
+  --tb-input-bg: #1f1f23;
+  --tb-placeholder: #71717a;
 }
 
 body {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -196,7 +196,7 @@ export default function Settings() {
                 onClick={() => setTheme(option.value)}
                 className={`rounded-xl px-4 py-2 text-sm ${
                   isSelected
-                    ? "border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] font-semibold text-[var(--tb-text)] ring-2 ring-[var(--tb-border)]"
+                    ? "border border-[var(--tb-border)] bg-[var(--tb-input-bg)] font-semibold text-[var(--tb-text)] ring-2 ring-[var(--tb-border)]"
                     : isLocked
                       ? "cursor-not-allowed border border-[var(--tb-border)] bg-[var(--tb-input-bg)] text-[var(--tb-muted)] opacity-70"
                       : "border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] text-[var(--tb-text)] hover:ring-2 hover:ring-[var(--tb-border)]"


### PR DESCRIPTION
## 概要
  theme="dark" 時に --tb-* が light 値へフォールバックしていた問題を修正し、Settings のテーマ選択ボタン selected
  表示を固定色非依存のトークン参照へ統一しました。これにより Dark/Premium 含む全テーマで白飛びしない選択表示にな
  ります。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/index.css:16 の html.dark に dark 用トークンを追加。
      - --tb-page-bg
      - --tb-surface-bg
      - --tb-text
      - --tb-muted
      - --tb-border
      - --tb-input-bg
      - --tb-placeholder
  - src/pages/Settings.tsx:199 のテーマボタン selected スタイルを調整。
      - 変更前: bg-[var(--tb-surface-bg)] ... ring
      - 変更後: bg-[var(--tb-input-bg)] ... ring
  - selected/disabled/hover すべてが --tb-* のみ参照し、bg-white 等の固定色依存を回避。

## 検証方法
  1. npm run lint
  2. npm run build
  3. Settings で Light / Dark / Soft Dark / Ivory / Ash Grey を順に選択し、テーマボタンの selected 表示が白飛び
     せず読めることを確認
  4. theme="dark"（Dark選択）時に Settings セクション背景・テキストが暗色で表示されることを確認
  5. Premiumテーマ（Soft Dark / Ivory / Ash Grey）でも selected 表示と本文可読性が崩れないことを確認

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
  - Darkトークン未定義の解消
  - テーマ選択ボタン selected 表示のトークン化微修正
- スコープ外:
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
- 
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要であれば、他ページの selected UI も同様の bg-[var(--tb-input-bg)] + ring パターンへ揃えられます。 

## 未解決の質問
- 
