### PR TITLE
fix semantic colors

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -31,7 +31,13 @@ const sectionClass =
   "rounded-3xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] p-6 shadow-sm";
 const mutedTextClass = "text-[var(--tb-muted)]";
 const buttonClass =
-  "rounded-xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] px-4 py-2 text-sm text-[var(--tb-text)] transition hover:opacity-90";
+  "rounded-xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] px-4 py-2 text-sm text-[var(--tb-text)] transition hover:bg-[var(--tb-input-bg)] hover:ring-1 hover:ring-[var(--tb-border)]";
+const primaryButtonClass =
+  "rounded-xl border border-zinc-900 bg-zinc-900 px-4 py-2 text-sm text-white transition hover:bg-zinc-800 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200";
+const dangerButtonClass =
+  "rounded-xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] px-4 py-2 text-sm text-[var(--tb-text)] transition hover:border-red-300 hover:bg-red-50 hover:text-red-700 dark:hover:border-red-800 dark:hover:bg-red-950/30 dark:hover:text-red-300";
+const premiumActionHoverClass =
+  "border-[var(--tb-border)] bg-[var(--tb-surface-bg)] text-[var(--tb-text)] hover:border-amber-300 hover:bg-amber-50 hover:text-amber-800 dark:hover:border-amber-800 dark:hover:bg-amber-950/30 dark:hover:text-amber-300";
 const textAreaClass =
   "w-full rounded-2xl border border-[var(--tb-border)] bg-[var(--tb-input-bg)] px-3 py-2 text-sm text-[var(--tb-text)] outline-none placeholder:text-[var(--tb-placeholder)] focus:border-[var(--tb-border)] focus:ring-2 focus:ring-[var(--tb-border)]/50";
 
@@ -228,7 +234,13 @@ export default function Settings() {
         <div className="mt-4 grid gap-2 text-sm">
           <div className="flex items-center gap-2">
             <span className={mutedTextClass}>Status:</span>
-            <span className="font-medium">
+            <span
+              className={
+                premiumActive
+                  ? "font-medium text-emerald-600 dark:text-emerald-400"
+                  : `font-medium ${mutedTextClass}`
+              }
+            >
               {premiumActive ? "Active" : "Inactive"}
             </span>
           </div>
@@ -254,7 +266,7 @@ export default function Settings() {
             className={`rounded-xl border px-4 py-2 text-sm transition ${
               isActivateDisabled
                 ? "cursor-not-allowed border-[var(--tb-border)] bg-[var(--tb-input-bg)] text-[var(--tb-muted)] opacity-70"
-                : "border-[var(--tb-border)] bg-[var(--tb-surface-bg)] text-[var(--tb-text)] hover:ring-2 hover:ring-[var(--tb-border)]"
+                : premiumActionHoverClass
             }`}
           >
             {isActivateDisabled
@@ -264,7 +276,7 @@ export default function Settings() {
           <button
             type="button"
             onClick={openResetModal}
-            className={buttonClass}
+            className={dangerButtonClass}
           >
             Reset to Free
           </button>
@@ -435,7 +447,7 @@ export default function Settings() {
                   <button
                     type="button"
                     onClick={handleConfirmReset}
-                    className={buttonClass}
+                    className={primaryButtonClass}
                   >
                     Confirm
                   </button>


### PR DESCRIPTION
## 概要
  テーマトークン基盤は維持したまま、Premium周りの意味色（Active緑・危険赤・主ボタン強調）と hover 表現を
  Settings に復元しました。あわせて Confirm/Cancel モーダルで主従を再導入し、操作意図が視覚的に分かるようにしま
  した。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/pages/Settings.tsx:35 に主ボタン用 primaryButtonClass を追加（Confirm の強調）。
  - src/pages/Settings.tsx:37 に危険操作用 dangerButtonClass を追加（Reset の赤 hover）。
  - src/pages/Settings.tsx:39 に Premium操作向け premiumActionHoverClass を追加（Activate の amber hover）。
  - src/pages/Settings.tsx:34 の共通 buttonClass を hover:opacity から「背景+リング」hover に変更し、全テーマで
    視認性を改善。
  - src/pages/Settings.tsx:237 の Status 表示を条件分岐し、Active を text-emerald-600 dark:text-emerald-400、
    Inactive を中立色へ変更。
  - src/pages/Settings.tsx:276 の Reset to Free に危険色 hover を適用。
  - src/pages/Settings.tsx:266 の Activate に意味色 hover（amber系）を適用。
  - src/pages/Settings.tsx の Confirm/Cancel モーダルで、Cancel は副ボタン、Confirm は主ボタン（濃色）に変更。

## 検証方法
  1. npm run lint
  2. npm run build
  3. Settings の Premium セクションで Status: Active が緑、Inactive が中立色で表示されることを確認。
  4. Reset to Free に hover すると赤系の強調が出ることを確認（Light/Dark/Premiumテーマで視認可能）。
  5. Activate Premium (+30 days) の hover がテーマに埋もれず認識できることを確認。
  6. Reset確認モーダルで Confirm が主（濃い背景）、Cancel が副（アウトライン）として見分けられることを確認。

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
  - Settings の意味色・hover表現の復元
  - Confirm/Cancel の主従復元
- スコープ外:
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - 意味色は固定クラスを重ねているため、将来トークン体系をさらに厳密化する場合は再調整が必要です。
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要であれば同じ意味色ルールを Home / Detail の危険操作（Delete等）にも横展開できます。

## 未解決の質問
- 
