### PR TITLE
arrange semantic color buttons settings

### DIFF
--- a/src/components/buttonVariants.ts
+++ b/src/components/buttonVariants.ts
@@ -1,0 +1,29 @@
+export type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "premium"
+  | "premiumDisabled"
+  | "success"
+  | "danger";
+
+const buttonBaseClass =
+  "rounded-xl border px-4 py-2 text-sm transition-colors transition-shadow";
+
+const buttonVariantClasses: Record<ButtonVariant, string> = {
+  primary:
+    "border-zinc-900 bg-zinc-900 text-white hover:bg-zinc-800 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200",
+  secondary:
+    "border-[var(--tb-border)] bg-[var(--tb-surface-bg)] text-[var(--tb-text)] hover:bg-[var(--tb-input-bg)] hover:ring-1 hover:ring-[var(--tb-border)]",
+  premium:
+    "border-[var(--tb-border)] bg-[var(--tb-surface-bg)] text-[var(--tb-text)] hover:border-amber-300 hover:bg-amber-50 hover:text-amber-800 dark:hover:border-amber-800 dark:hover:bg-amber-950/30 dark:hover:text-amber-300",
+  premiumDisabled:
+    "cursor-not-allowed border-amber-200 bg-amber-50 text-amber-700 opacity-80 dark:border-amber-900/70 dark:bg-amber-950/30 dark:text-amber-300",
+  success:
+    "border-[var(--tb-border)] bg-[var(--tb-surface-bg)] text-[var(--tb-text)] hover:border-emerald-300 hover:bg-emerald-50 hover:text-emerald-700 dark:hover:border-emerald-800 dark:hover:bg-emerald-950/30 dark:hover:text-emerald-300",
+  danger:
+    "border-[var(--tb-border)] bg-[var(--tb-surface-bg)] text-[var(--tb-text)] hover:border-red-300 hover:bg-red-50 hover:text-red-700 dark:hover:border-red-800 dark:hover:bg-red-950/30 dark:hover:text-red-300",
+};
+
+export function getButtonClass(variant: ButtonVariant): string {
+  return `${buttonBaseClass} ${buttonVariantClasses[variant]}`;
+}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -8,6 +8,7 @@ import {
   parseTags,
   updateTrail,
 } from "../data/trails";
+import { getButtonClass } from "../components/buttonVariants";
 
 export default function Detail() {
   const navigate = useNavigate();
@@ -129,14 +130,14 @@ export default function Detail() {
         <div className="mt-6 flex flex-wrap gap-3">
           <Link
             to="/"
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm transition-colors transition-shadow hover:border-zinc-300 hover:bg-zinc-100 hover:shadow-sm dark:border-zinc-700 dark:hover:border-zinc-700 dark:hover:bg-zinc-700"
+            className={getButtonClass("secondary")}
           >
             Back
           </Link>
           <button
             type="button"
             onClick={handleStartEdit}
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors transition-shadow hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700 hover:shadow-sm dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-emerald-900/70 dark:hover:bg-emerald-950/40 dark:hover:text-emerald-300"
+            className={getButtonClass("success")}
           >
             Edit
           </button>
@@ -144,7 +145,7 @@ export default function Detail() {
             type="button"
             onClick={handleDelete}
             disabled={isDeleting}
-            className="rounded-xl border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors transition-shadow hover:border-red-200 hover:bg-red-50 hover:text-red-700 hover:shadow-sm dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-red-900/70 dark:hover:bg-red-950/40 dark:hover:text-red-300"
+            className={getButtonClass("danger")}
           >
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
@@ -204,13 +205,13 @@ export default function Detail() {
               <button
                 type="button"
                 onClick={handleCancelEdit}
-                className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
+                className={getButtonClass("secondary")}
               >
                 Cancel
               </button>
               <button
                 type="submit"
-                className="rounded-xl bg-zinc-900 px-4 py-2 text-sm text-white hover:opacity-90 dark:bg-zinc-100 dark:text-zinc-900"
+                className={getButtonClass("primary")}
               >
                 Save
               </button>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -23,6 +23,7 @@ import {
   THEME_OPTIONS,
   type AppTheme,
 } from "../data/theme";
+import { getButtonClass } from "../components/buttonVariants";
 
 type PremiumActionType = "activate" | "reset";
 
@@ -30,14 +31,6 @@ const PROMPT_QUESTION = "人生であった一番甘酸っぱい瞬間は？";
 const sectionClass =
   "rounded-3xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] p-6 shadow-sm";
 const mutedTextClass = "text-[var(--tb-muted)]";
-const buttonClass =
-  "rounded-xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] px-4 py-2 text-sm text-[var(--tb-text)] transition hover:bg-[var(--tb-input-bg)] hover:ring-1 hover:ring-[var(--tb-border)]";
-const primaryButtonClass =
-  "rounded-xl border border-zinc-900 bg-zinc-900 px-4 py-2 text-sm text-white transition hover:bg-zinc-800 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200";
-const dangerButtonClass =
-  "rounded-xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] px-4 py-2 text-sm text-[var(--tb-text)] transition hover:border-red-300 hover:bg-red-50 hover:text-red-700 dark:hover:border-red-800 dark:hover:bg-red-950/30 dark:hover:text-red-300";
-const premiumActionHoverClass =
-  "border-[var(--tb-border)] bg-[var(--tb-surface-bg)] text-[var(--tb-text)] hover:border-amber-300 hover:bg-amber-50 hover:text-amber-800 dark:hover:border-amber-800 dark:hover:bg-amber-950/30 dark:hover:text-amber-300";
 const textAreaClass =
   "w-full rounded-2xl border border-[var(--tb-border)] bg-[var(--tb-input-bg)] px-3 py-2 text-sm text-[var(--tb-text)] outline-none placeholder:text-[var(--tb-placeholder)] focus:border-[var(--tb-border)] focus:ring-2 focus:ring-[var(--tb-border)]/50";
 
@@ -263,11 +256,9 @@ export default function Settings() {
             type="button"
             disabled={isActivateDisabled}
             onClick={openActivateModal}
-            className={`rounded-xl border px-4 py-2 text-sm transition ${
-              isActivateDisabled
-                ? "cursor-not-allowed border-[var(--tb-border)] bg-[var(--tb-input-bg)] text-[var(--tb-muted)] opacity-70"
-                : premiumActionHoverClass
-            }`}
+            className={getButtonClass(
+              isActivateDisabled ? "premiumDisabled" : "premium"
+            )}
           >
             {isActivateDisabled
               ? "Premium Active (+30 days locked)"
@@ -276,7 +267,7 @@ export default function Settings() {
           <button
             type="button"
             onClick={openResetModal}
-            className={dangerButtonClass}
+            className={getButtonClass("danger")}
           >
             Reset to Free
           </button>
@@ -321,7 +312,7 @@ export default function Settings() {
           <button
             type="button"
             onClick={handleExportJson}
-            className={buttonClass}
+            className={getButtonClass("secondary")}
           >
             Export JSON
           </button>
@@ -343,7 +334,7 @@ export default function Settings() {
           <button
             type="button"
             onClick={handleImportJson}
-            className={buttonClass}
+            className={getButtonClass("secondary")}
           >
             Import JSON
           </button>
@@ -374,14 +365,14 @@ export default function Settings() {
                     <button
                       type="button"
                       onClick={handleActivateWithLocalRoute}
-                      className={`w-full text-left ${buttonClass}`}
+                      className={`w-full text-left ${getButtonClass("secondary")}`}
                     >
                       0円で今月分を有効化する（local / mock）
                     </button>
                     <button
                       type="button"
                       onClick={handleOpenPromptRoute}
-                      className={`w-full text-left ${buttonClass}`}
+                      className={`w-full text-left ${getButtonClass("secondary")}`}
                     >
                       お題で1ヶ月分を肩代わりする（prompt）
                     </button>
@@ -405,14 +396,14 @@ export default function Settings() {
                       <button
                         type="button"
                         onClick={() => setShowPromptRoute(false)}
-                        className={buttonClass}
+                        className={getButtonClass("secondary")}
                       >
                         Back
                       </button>
                       <button
                         type="button"
                         onClick={handleSubmitPromptRoute}
-                        className={buttonClass}
+                        className={getButtonClass("secondary")}
                       >
                         回答して有効化
                       </button>
@@ -440,14 +431,14 @@ export default function Settings() {
                   <button
                     type="button"
                     onClick={closePremiumModal}
-                    className={buttonClass}
+                    className={getButtonClass("secondary")}
                   >
                     Cancel
                   </button>
                   <button
                     type="button"
                     onClick={handleConfirmReset}
-                    className={primaryButtonClass}
+                    className={getButtonClass("primary")}
                   >
                     Confirm
                   </button>


### PR DESCRIPTION
## 概要
  Settings/Detail の「意味色」を共通化し、Premium=gold、Edit=green、Delete/Reset=red の hover/見た目を統一しました。加えて、  Premium Active (+30 days locked) の disabled を薄ゴールド固定にして hover 非反応にしました。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/components/buttonVariants.ts を追加し、共通 variant を定義
  - variant 追加:
      - primary
      - secondary
      - premium
      - premiumDisabled
      - success
      - danger
  - src/pages/Settings.tsx
      - 既存ローカルボタンクラスを共通 variant に置換
      - Premium Active (+30 days locked) を premiumDisabled に変更（薄ゴールド固定、hoverなし）
      - Reset to Free を danger に統一（薄レッドhover）
      - Confirm/Cancel は primary / secondary の差を維持
  - src/pages/Detail.tsx
      - Edit を success（薄グリーンhover）に統一
      - Delete を danger（薄レッドhover）に統一
      - Cancel/Save を secondary/primary に統一

## 検証方法
  1. npm run build
  2. npm run dev
  3. /settings を開いて確認
  4. Premium が Active の状態で Premium Active (+30 days locked) が薄ゴールド固定で hover 変化しないこと
  5. /settings の Reset to Free で薄レッド hover が light/dark/premium テーマで視認できること
  6. /trail/:id を開いて Edit が薄グリーン hover、Delete が薄レッド hover になること
  7. Settings の Confirm モーダルで Confirm が主ボタン、Cancel が副ボタン見た目のままであること

コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:
  - 含む: Settings/Detail の意味色統一、最小限の共通化（button variant）
- スコープ外:
  - 含まない: ボタンコンポーネント全面刷新、アニメーション追加
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - Detail の Delete は disabled 時も通常クラスを使うため、将来 disabled 専用見た目が必要なら追加調整が必要
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要なら disabled 専用 variant（例: dangerDisabled）を追加して操作中状態をさらに明確化

## 未解決の質問
- 
