### PR TITLE
arrange hashtag pills

### DIFF
--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -113,7 +113,7 @@ export default function Detail() {
           {trail.tags.map((tag) => (
             <span
               key={tag}
-              className="rounded-full bg-zinc-900 px-3 py-1 text-xs text-white dark:bg-zinc-100 dark:text-zinc-900"
+              className="rounded-full border border-[var(--tb-border)] bg-[var(--tb-input-bg)] px-3 py-1 text-xs text-[var(--tb-text)]"
             >
               #{tag}
             </span>


### PR DESCRIPTION
## 概要
  詳細ページのタグ pill を固定色からテーマトークン参照へ変更し、Light/Dark/Premium すべてで背景同化しにくい可読な表示に統一
  しました。

## 変更内容
- [x] UI
- [ ] Routing
- [ ] State management
- [x] Refactor
- [ ] Config/Tooling (only if requested)
- [ ] Other:

  - src/pages/Detail.tsx:116 のタグ pill クラスを更新
  - 変更前: bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900（固定色依存）
  - 変更後: border-[var(--tb-border)] bg-[var(--tb-input-bg)] text-[var(--tb-text)]（テーマ追従）

## 検証方法
  1. npm run build
  2. npm run dev
  3. /trail/:id を開く
  4. Light / Dark / Premium（soft-dark, ivory, ash-grey）を切り替えて、タグ pill の文字・背景・枠線が読めることを確認
コマンド:
- `npm i`
- `npm run build`
- `npm run dev`

## スコープ / スコープ外
- スコープ内:Detailページのタグ pill 可読性改善（最小変更）
- スコープ外:タグデザイン全面刷新、カテゴリ別色分け
- 学習・実証環境としての影響（該当する場合）:

## リスク / トレードオフ
  - 現時点では --tb-input-bg / --tb-border の既存トークン値をそのまま利用しているため、将来テーマ値が極端に近接すると再調整が必要になる可能性あり
- 破壊的変更の可能性（ある場合は明記）:

## スクリーンショット（任意）
- 

## フォローアップ
  - 必要なら src/index.css の Premium テーマの --tb-input-bg と --tb-border のコントラストを軽く上げる

## 未解決の質問
- 
