### PR TITLE
refactor button components

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,25 @@
+import type { ButtonHTMLAttributes } from "react";
+import { getButtonClass, type ButtonVariant } from "../buttonVariants";
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+};
+
+export default function Button({
+  variant = "secondary",
+  className,
+  type,
+  ...props
+}: ButtonProps) {
+  const resolvedClassName = [getButtonClass(variant), className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button
+      type={type ?? "button"}
+      className={resolvedClassName}
+      {...props}
+    />
+  );
+}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { FormEvent } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import {
   deleteTrail,
   getTrail,
@@ -8,7 +8,7 @@ import {
   parseTags,
   updateTrail,
 } from "../data/trails";
-import { getButtonClass } from "../components/buttonVariants";
+import Button from "../components/ui/Button";
 
 export default function Detail() {
   const navigate = useNavigate();
@@ -95,9 +95,9 @@ export default function Detail() {
     return (
       <div className="rounded-3xl border border-zinc-200 bg-white p-6 dark:border-zinc-700 dark:bg-zinc-800">
         <div className="text-sm text-zinc-500">Not found</div>
-        <Link className="mt-3 inline-block text-sm underline" to="/">
+        <Button className="mt-3 inline-block text-sm underline" onClick={() => navigate("/")}>
           Back to Home
-        </Link>
+        </Button>
       </div>
     );
   }
@@ -128,27 +128,15 @@ export default function Detail() {
         </div>
 
         <div className="mt-6 flex flex-wrap gap-3">
-          <Link
-            to="/"
-            className={getButtonClass("secondary")}
-          >
+          <Button variant="secondary" onClick={() => navigate("/")}>
             Back
-          </Link>
-          <button
-            type="button"
-            onClick={handleStartEdit}
-            className={getButtonClass("success")}
-          >
+          </Button>
+          <Button variant="success" onClick={handleStartEdit}>
             Edit
-          </button>
-          <button
-            type="button"
-            onClick={handleDelete}
-            disabled={isDeleting}
-            className={getButtonClass("danger")}
-          >
+          </Button>
+          <Button variant="danger" onClick={handleDelete} disabled={isDeleting}>
             {isDeleting ? "Deleting..." : "Delete"}
-          </button>
+          </Button>
         </div>
 
         {isEditing && (
@@ -202,19 +190,12 @@ export default function Detail() {
             )}
 
             <div className="flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={handleCancelEdit}
-                className={getButtonClass("secondary")}
-              >
+              <Button variant="secondary" onClick={handleCancelEdit}>
                 Cancel
-              </button>
-              <button
-                type="submit"
-                className={getButtonClass("primary")}
-              >
+              </Button>
+              <Button type="submit" variant="primary">
                 Save
-              </button>
+              </Button>
             </div>
           </form>
         )}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,6 +10,7 @@ import {
 } from "../data/trails";
 import type { Trail } from "../data/trails";
 import { isPremiumActive, loadEntitlement } from "../data/entitlement";
+import Button from "../components/ui/Button";
 
 const FREE_CARD_LIMIT = 10;
 
@@ -138,18 +139,18 @@ export default function Home() {
               カードをクリックすると詳細へ遷移します。
             </p>
           </div>
-          <button
-            type="button"
+          <Button
+            variant="primary"
             onClick={handleOpenModal}
             disabled={isCreateLimitReached}
-            className={`shrink-0 rounded-xl px-3 py-2 text-sm border border-transparent ${
+            className={`shrink-0 px-3 py-2 ${
               isCreateLimitReached
-                ? "cursor-not-allowed bg-[var(--tb-border)] text-[var(--tb-muted)]"
-                : "bg-[var(--tb-text)] text-[var(--tb-surface-bg)] hover:hover:brightness-110"
+                ? "border-transparent bg-[var(--tb-border)] text-[var(--tb-muted)] disabled:opacity-100"
+                : "border-[var(--tb-text)] hover:opacity-100 hover:brightness-110"
             }`}
           >
             + New
-          </button>
+          </Button>
         </div>
         {isCreateLimitReached && (
           <p className="mt-3 text-sm text-amber-700 dark:text-amber-300">
@@ -325,19 +326,12 @@ export default function Home() {
             )}
 
             <div className="mt-5 flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={closeModal}
-                className="rounded-xl border border-zinc-200 px-4 py-2 text-sm hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-700"
-              >
+              <Button variant="secondary" onClick={closeModal}>
                 Cancel
-              </button>
-              <button
-                type="submit"
-                className="rounded-xl bg-zinc-900 px-4 py-2 text-sm text-white hover:opacity-90 dark:bg-zinc-100 dark:text-zinc-900"
-              >
+              </Button>
+              <Button type="submit" variant="primary">
                 Save
-              </button>
+              </Button>
             </div>
           </form>
         </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -23,7 +23,7 @@ import {
   THEME_OPTIONS,
   type AppTheme,
 } from "../data/theme";
-import { getButtonClass } from "../components/buttonVariants";
+import Button from "../components/ui/Button";
 
 type PremiumActionType = "activate" | "reset";
 
@@ -252,25 +252,18 @@ export default function Settings() {
         </div>
 
         <div className="mt-5 flex flex-wrap gap-3">
-          <button
-            type="button"
+          <Button
+            variant={isActivateDisabled ? "premiumDisabled" : "premium"}
             disabled={isActivateDisabled}
             onClick={openActivateModal}
-            className={getButtonClass(
-              isActivateDisabled ? "premiumDisabled" : "premium"
-            )}
           >
             {isActivateDisabled
               ? "Premium Active (+30 days locked)"
               : "Activate Premium (+30 days)"}
-          </button>
-          <button
-            type="button"
-            onClick={openResetModal}
-            className={getButtonClass("danger")}
-          >
+          </Button>
+          <Button variant="danger" onClick={openResetModal}>
             Reset to Free
-          </button>
+          </Button>
         </div>
 
         <div className="mt-5 rounded-2xl border border-[var(--tb-border)] p-4 text-sm">
@@ -309,13 +302,9 @@ export default function Settings() {
         </p>
 
         <div className="mt-4 space-y-3">
-          <button
-            type="button"
-            onClick={handleExportJson}
-            className={getButtonClass("secondary")}
-          >
+          <Button variant="secondary" onClick={handleExportJson}>
             Export JSON
-          </button>
+          </Button>
           <textarea
             value={exportJson}
             readOnly
@@ -331,13 +320,9 @@ export default function Settings() {
             placeholder="Paste backup JSON to import (overwrite)."
             className={`min-h-36 text-xs ${textAreaClass}`}
           />
-          <button
-            type="button"
-            onClick={handleImportJson}
-            className={getButtonClass("secondary")}
-          >
+          <Button variant="secondary" onClick={handleImportJson}>
             Import JSON
-          </button>
+          </Button>
           {dataError && (
             <p className={`text-sm ${mutedTextClass}`}>{dataError}</p>
           )}
@@ -362,20 +347,20 @@ export default function Settings() {
 
                 {!showPromptRoute ? (
                   <div className="mt-5 space-y-2">
-                    <button
-                      type="button"
+                    <Button
+                      variant="secondary"
                       onClick={handleActivateWithLocalRoute}
-                      className={`w-full text-left ${getButtonClass("secondary")}`}
+                      className="w-full text-left"
                     >
                       0円で今月分を有効化する（local / mock）
-                    </button>
-                    <button
-                      type="button"
+                    </Button>
+                    <Button
+                      variant="secondary"
                       onClick={handleOpenPromptRoute}
-                      className={`w-full text-left ${getButtonClass("secondary")}`}
+                      className="w-full text-left"
                     >
                       お題で1ヶ月分を肩代わりする（prompt）
-                    </button>
+                    </Button>
                   </div>
                 ) : (
                   <div className="mt-5 space-y-3">
@@ -393,20 +378,18 @@ export default function Settings() {
                       <p className={`text-sm ${mutedTextClass}`}>{promptError}</p>
                     )}
                     <div className="flex justify-between gap-2">
-                      <button
-                        type="button"
+                      <Button
+                        variant="secondary"
                         onClick={() => setShowPromptRoute(false)}
-                        className={getButtonClass("secondary")}
                       >
                         Back
-                      </button>
-                      <button
-                        type="button"
+                      </Button>
+                      <Button
+                        variant="secondary"
                         onClick={handleSubmitPromptRoute}
-                        className={getButtonClass("secondary")}
                       >
                         回答して有効化
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 )}
@@ -428,20 +411,12 @@ export default function Settings() {
                   Freeに戻します。よろしいですか？
                 </p>
                 <div className="mt-5 flex justify-end gap-2">
-                  <button
-                    type="button"
-                    onClick={closePremiumModal}
-                    className={getButtonClass("secondary")}
-                  >
+                  <Button variant="secondary" onClick={closePremiumModal}>
                     Cancel
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleConfirmReset}
-                    className={getButtonClass("primary")}
-                  >
+                  </Button>
+                  <Button variant="primary" onClick={handleConfirmReset}>
                     Confirm
-                  </button>
+                  </Button>
                 </div>
               </>
             )}


### PR DESCRIPTION
## 概要
  getButtonClass()/ButtonVariant を Button コンポーネントに集約し、Settings / Detail / Home の主要アクションボタ
  ンを <Button> 利用に置き換えて JSX 可読性を上げました。既存 variant（primary/secondary/premium/
  premiumDisabled/success/danger）の見た目・hover・disabled 振る舞いを維持しています。

## 変更内容
 - [ ] UI
 - [ ] Routing
 - [ ] State management
 - [x] Refactor
 - [ ] Config/Tooling (only if requested)
 - [ ] Other:

### 内容詳細

  - 追加: src/components/ui/Button.tsx
      - variant prop を受け取り、内部で getButtonClass(variant) を適用
      - className 上書きと type デフォルト（button）対応
  - 変更: src/pages/Settings.tsx
      - 主要ボタンを getButtonClass(...) 直呼びから <Button variant="..."> に置換
      - Premium 操作・Data 操作・Confirm モーダルの主要ボタンを統一
  - 変更: src/pages/Detail.tsx
      - Back/Edit/Delete/Cancel/Save を <Button> 化
      - getButtonClass のページ直利用を解消
  - 変更: src/pages/Home.tsx
      - + New、作成モーダルの Cancel/Save を <Button> 化
      - + New は既存 hover/disabled の印象を保つために追加クラスで調整

## 検証方法
  1. npm run build
  2. npm run dev
  3. Home で + New、モーダルの Cancel/Save の見た目・hover・disabled を確認
  4. Settings で Premium/Data/Confirm 関連ボタンの見た目と挙動が従来どおりか確認
  5. Detail で Back/Edit/Delete と編集フォーム Cancel/Save の見た目・挙動を確認

## スコープ
 - スコープ内:ボタン周りのコンポーネント化、主要ボタンの置換

 - スコープ外:全コンポーネントの全面リファクタ、モーダル切り出し

- 学習・実証環境としての影響（該当する場合）:


## リスク / トレードオフ
  - Home の + New は既存見た目維持のため Button に画面固有クラスを上乗せしており、将来 variant 側の仕様変更時に
    再確認が必要

 - 破壊的変更の可能性（ある場合は明記）:


## スクリーンショット（任意）
 - 


## フォローアップ

  - Home のタグフィルタ用ボタンや Settings のテーマ選択ボタンも、必要なら次段で Button に寄せて統一可能

## 未解決の質問
 - 
