### PR TITLE
refactor modal components

### DIFF
--- a/src/components/settings/PremiumActionModal.tsx
+++ b/src/components/settings/PremiumActionModal.tsx
@@ -1,0 +1,117 @@
+import Button from "../ui/Button";
+import Modal from "../ui/Modal";
+
+export type PremiumActionType = "activate" | "reset";
+
+type PremiumActionModalProps = {
+  action: PremiumActionType | null;
+  showPromptRoute: boolean;
+  promptQuestion: string;
+  promptAnswer: string;
+  promptError: string | null;
+  onClose: () => void;
+  onActivateWithLocalRoute: () => void;
+  onOpenPromptRoute: () => void;
+  onBackFromPromptRoute: () => void;
+  onPromptAnswerChange: (nextAnswer: string) => void;
+  onSubmitPromptRoute: () => void;
+  onConfirmReset: () => void;
+};
+
+const mutedTextClass = "text-[var(--tb-muted)]";
+const textAreaClass =
+  "min-h-28 w-full rounded-2xl border border-[var(--tb-border)] bg-[var(--tb-input-bg)] px-3 py-2 text-sm text-[var(--tb-text)] outline-none placeholder:text-[var(--tb-placeholder)] focus:border-[var(--tb-border)] focus:ring-2 focus:ring-[var(--tb-border)]/50";
+
+export default function PremiumActionModal({
+  action,
+  showPromptRoute,
+  promptQuestion,
+  promptAnswer,
+  promptError,
+  onClose,
+  onActivateWithLocalRoute,
+  onOpenPromptRoute,
+  onBackFromPromptRoute,
+  onPromptAnswerChange,
+  onSubmitPromptRoute,
+  onConfirmReset,
+}: PremiumActionModalProps) {
+  return (
+    <Modal isOpen={Boolean(action)} onClose={onClose}>
+      {action === "activate" ? (
+        <>
+          <h3 className="text-base font-semibold">Activate Premium</h3>
+          <p className={`mt-2 text-sm ${mutedTextClass}`}>
+            Premiumは0円/1カ月です。付与方法を選んでください。
+          </p>
+
+          {!showPromptRoute ? (
+            <div className="mt-5 space-y-2">
+              <Button
+                variant="secondary"
+                onClick={onActivateWithLocalRoute}
+                className="w-full text-left"
+              >
+                0円で今月分を有効化する（local / mock）
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={onOpenPromptRoute}
+                className="w-full text-left"
+              >
+                お題で1ヶ月分を肩代わりする（prompt）
+              </Button>
+            </div>
+          ) : (
+            <div className="mt-5 space-y-3">
+              <div className="rounded-2xl border border-[var(--tb-border)] p-3 text-sm">
+                <div className={mutedTextClass}>お題</div>
+                <div className="mt-1">{promptQuestion}</div>
+              </div>
+              <textarea
+                value={promptAnswer}
+                onChange={(event) => onPromptAnswerChange(event.target.value)}
+                placeholder="回答を入力してください"
+                className={textAreaClass}
+              />
+              {promptError && <p className={`text-sm ${mutedTextClass}`}>{promptError}</p>}
+              <div className="flex justify-between gap-2">
+                <Button variant="secondary" onClick={onBackFromPromptRoute}>
+                  Back
+                </Button>
+                <Button variant="secondary" onClick={onSubmitPromptRoute}>
+                  回答して有効化
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <div className="mt-4 flex justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-xl px-3 py-2 text-xs text-[var(--tb-muted)] transition hover:bg-[var(--tb-input-bg)]"
+            >
+              Close
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <h3 className="text-base font-semibold">Confirm action</h3>
+          <p className={`mt-2 text-sm ${mutedTextClass}`}>
+            Freeに戻します。よろしいですか？
+          </p>
+          <div className="mt-5 flex justify-end gap-2">
+            <Button variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={onConfirmReset}>
+              Confirm
+            </Button>
+          </div>
+        </>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+type ModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  panelClassName?: string;
+};
+
+const overlayClassName =
+  "fixed inset-0 z-40 flex items-end justify-center bg-zinc-950/45 p-4 sm:items-center";
+const panelBaseClassName =
+  "w-full max-w-md rounded-3xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] p-5 shadow-lg";
+
+export default function Modal({
+  isOpen,
+  onClose,
+  children,
+  panelClassName,
+}: ModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className={overlayClassName} onClick={onClose}>
+      <div
+        className={[panelBaseClassName, panelClassName].filter(Boolean).join(" ")}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -24,8 +24,9 @@ import {
   type AppTheme,
 } from "../data/theme";
 import Button from "../components/ui/Button";
-
-type PremiumActionType = "activate" | "reset";
+import PremiumActionModal, {
+  type PremiumActionType,
+} from "../components/settings/PremiumActionModal";
 
 const PROMPT_QUESTION = "人生であった一番甘酸っぱい瞬間は？";
 const sectionClass =
@@ -329,100 +330,20 @@ export default function Settings() {
         </div>
       </section>
 
-      {pendingPremiumAction && (
-        <div
-          className="fixed inset-0 z-40 flex items-end justify-center bg-zinc-950/45 p-4 sm:items-center"
-          onClick={closePremiumModal}
-        >
-          <div
-            className="w-full max-w-md rounded-3xl border border-[var(--tb-border)] bg-[var(--tb-surface-bg)] p-5 shadow-lg"
-            onClick={(event) => event.stopPropagation()}
-          >
-            {pendingPremiumAction === "activate" ? (
-              <>
-                <h3 className="text-base font-semibold">Activate Premium</h3>
-                <p className={`mt-2 text-sm ${mutedTextClass}`}>
-                  Premiumは0円/1カ月です。付与方法を選んでください。
-                </p>
-
-                {!showPromptRoute ? (
-                  <div className="mt-5 space-y-2">
-                    <Button
-                      variant="secondary"
-                      onClick={handleActivateWithLocalRoute}
-                      className="w-full text-left"
-                    >
-                      0円で今月分を有効化する（local / mock）
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      onClick={handleOpenPromptRoute}
-                      className="w-full text-left"
-                    >
-                      お題で1ヶ月分を肩代わりする（prompt）
-                    </Button>
-                  </div>
-                ) : (
-                  <div className="mt-5 space-y-3">
-                    <div className="rounded-2xl border border-[var(--tb-border)] p-3 text-sm">
-                      <div className={mutedTextClass}>お題</div>
-                      <div className="mt-1">{PROMPT_QUESTION}</div>
-                    </div>
-                    <textarea
-                      value={promptAnswer}
-                      onChange={(event) => setPromptAnswer(event.target.value)}
-                      placeholder="回答を入力してください"
-                      className={`min-h-28 ${textAreaClass}`}
-                    />
-                    {promptError && (
-                      <p className={`text-sm ${mutedTextClass}`}>{promptError}</p>
-                    )}
-                    <div className="flex justify-between gap-2">
-                      <Button
-                        variant="secondary"
-                        onClick={() => setShowPromptRoute(false)}
-                      >
-                        Back
-                      </Button>
-                      <Button
-                        variant="secondary"
-                        onClick={handleSubmitPromptRoute}
-                      >
-                        回答して有効化
-                      </Button>
-                    </div>
-                  </div>
-                )}
-
-                <div className="mt-4 flex justify-end">
-                  <button
-                    type="button"
-                    onClick={closePremiumModal}
-                    className="rounded-xl px-3 py-2 text-xs text-[var(--tb-muted)] transition hover:bg-[var(--tb-input-bg)]"
-                  >
-                    Close
-                  </button>
-                </div>
-              </>
-            ) : (
-              <>
-                <h3 className="text-base font-semibold">Confirm action</h3>
-                <p className={`mt-2 text-sm ${mutedTextClass}`}>
-                  Freeに戻します。よろしいですか？
-                </p>
-                <div className="mt-5 flex justify-end gap-2">
-                  <Button variant="secondary" onClick={closePremiumModal}>
-                    Cancel
-                  </Button>
-                  <Button variant="primary" onClick={handleConfirmReset}>
-                    Confirm
-                  </Button>
-                </div>
-              </>
-            )}
-          </div>
-        </div>
-      )}
+      <PremiumActionModal
+        action={pendingPremiumAction}
+        showPromptRoute={showPromptRoute}
+        promptQuestion={PROMPT_QUESTION}
+        promptAnswer={promptAnswer}
+        promptError={promptError}
+        onClose={closePremiumModal}
+        onActivateWithLocalRoute={handleActivateWithLocalRoute}
+        onOpenPromptRoute={handleOpenPromptRoute}
+        onBackFromPromptRoute={() => setShowPromptRoute(false)}
+        onPromptAnswerChange={setPromptAnswer}
+        onSubmitPromptRoute={handleSubmitPromptRoute}
+        onConfirmReset={handleConfirmReset}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 概要
  Settings.tsx の Premium 関連モーダル（confirm/choice/prompt）をコンポーネントへ切り出し、状態管理と表示責務を
  分離して可読性・保守性を改善しました。既存の表示条件・文言・操作フロー・テーマ追従は維持しています。

## 変更内容
 - [ ] UI
 - [ ] Routing
 - [ ] State management
 - [x] Refactor
 - [ ] Config/Tooling (only if requested)
 - [ ] Other:

### 内容詳細

  - 追加: src/components/ui/Modal.tsx
      - オーバーレイ、前面パネル、外側クリックで閉じる挙動を共通化
  - 追加: src/components/settings/PremiumActionModal.tsx
      - action に応じて activate（choice/prompt）と reset（confirm）を描画
      - choice:
          - local/mock ルート
          - prompt ルート
          - Close ボタン
      - confirm:
          - Cancel / Confirm の2択
          - 余分な Close はなし
  - 更新: src/pages/Settings.tsx
      - 巨大なモーダル JSX ブロックを削除
      - PremiumActionModal 呼び出しに置換
      - 状態管理・イベントハンドラは既存のまま保持（Escape close、Premium更新、履歴登録など）

## 検証方法
  1. npm run build
  2. npm run dev
  3. /settings で Activate Premium (+30 days) を押下
  4. choice モーダルで local/mock と prompt の分岐、Close 動作を確認
  5. prompt で空入力時エラー表示、入力後に Premium 有効化と履歴反映を確認
  6. Reset to Free で confirm モーダル（Cancel/Confirm）が表示され、Confirm で Free に戻ることを確認
  7. Light/Dark/Premium テーマでモーダル可読性が維持されることを確認

## スコープ
 - スコープ内: Settings 内モーダルUIのコンポーネント切り出し（confirm/choice/prompt）

 - スコープ外: モーダルデザイン刷新、高度アクセシビリティ対応、Premiumロジック変更

- 学習・実証環境としての影響（該当する場合）:


## リスク / トレードオフ
  - PremiumActionModal の props は最小構成だが数が多いため、将来分岐追加時にインターフェース整理が必要になる可能
    性あり

 - 破壊的変更の可能性（ある場合は明記）:


## スクリーンショット（任意）
 - 


## フォローアップ
  - 必要なら PremiumActionModal の activate 部分をさらに Choice / Prompt 小コンポーネントへ分離可能


## 未解決の質問
 - 
