### PR TITLE
[Trailboard] Home画面にClear filtersを追加

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -67,11 +67,17 @@ export default function Home() {
       return queryMatch && selectedTagMatch;
     });
   }, [items, query, selectedTags]);
+  const hasActiveFilters = query.trim().length > 0 || selectedTags.length > 0;
 
   function toggleTag(tag: string) {
     setSelectedTags((prev) =>
       prev.includes(tag) ? prev.filter((value) => value !== tag) : [...prev, tag]
     );
+  }
+
+  function clearFilters() {
+    setQuery("");
+    setSelectedTags([]);
   }
 
   function closeModal() {
@@ -161,12 +167,23 @@ export default function Home() {
       </section>
 
       <section className="rounded-3xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
-        <label
-          htmlFor="trail-search"
-          className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
-        >
-          Search
-        </label>
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+          <label
+            htmlFor="trail-search"
+            className="text-sm font-medium text-zinc-700 dark:text-zinc-300"
+          >
+            Search
+          </label>
+          {hasActiveFilters && (
+            <Button
+              variant="secondary"
+              onClick={clearFilters}
+              className="px-3 py-1.5 text-xs"
+            >
+              Clear filters
+            </Button>
+          )}
+        </div>
         <input
           id="trail-search"
           type="text"
@@ -181,15 +198,6 @@ export default function Home() {
             <p className="text-xs font-medium text-zinc-600 dark:text-zinc-300">
               Tags
             </p>
-            {selectedTags.length > 0 && (
-              <button
-                type="button"
-                onClick={() => setSelectedTags([])}
-                className="text-xs text-zinc-500 underline hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
-              >
-                Clear
-              </button>
-            )}
           </div>
 
           {tagSummaries.length === 0 ? (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -31,6 +31,7 @@ export default function Home() {
     [entitlement]
   );
   const isCreateLimitReached = !premiumActive && items.length >= FREE_CARD_LIMIT;
+  const normalizedQuery = query.trim().toLowerCase();
 
   const tagSummaries = useMemo(() => {
     const counts = new Map<string, number>();
@@ -52,22 +53,20 @@ export default function Home() {
   }, [items]);
 
   const filteredTrails = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
-
     return items.filter((trail) => {
       const queryMatch =
-        !normalized ||
-        trail.title.toLowerCase().includes(normalized) ||
-        trail.subtitle.toLowerCase().includes(normalized) ||
-        trail.tags.some((tag) => tag.toLowerCase().includes(normalized));
+        !normalizedQuery ||
+        trail.title.toLowerCase().includes(normalizedQuery) ||
+        trail.subtitle.toLowerCase().includes(normalizedQuery) ||
+        trail.tags.some((tag) => tag.toLowerCase().includes(normalizedQuery));
       const selectedTagMatch = selectedTags.every((selectedTag) =>
         trail.tags.some((tag) => tag.toLowerCase() === selectedTag)
       );
 
       return queryMatch && selectedTagMatch;
     });
-  }, [items, query, selectedTags]);
-  const hasActiveFilters = query.trim().length > 0 || selectedTags.length > 0;
+  }, [items, normalizedQuery, selectedTags]);
+  const hasActiveFilters = normalizedQuery.length > 0 || selectedTags.length > 0;
 
   function toggleTag(tag: string) {
     setSelectedTags((prev) =>


### PR DESCRIPTION
## 概要
 - Home画面に、検索文字列と選択中タグをまとめて解除できる `Clear filters` ボタンを追加しました。
 - フィルタ状態をワンクリックで初期化し、カード一覧を全件表示へ戻しやすくするためです。

## 変更内容
 - [x] UI
 - [ ] Routing
 - [x] State management
 - [ ] Refactor
 - [ ] Config/Tooling (only if requested)
 - [ ] Other:

#### 内容詳細
 - `src/pages/Home.tsx` に `hasActiveFilters` を追加し、検索文字列またはタグ選択があるときだけ `Clear filters` ボタンを表示するようにしました。
 - `clearFilters()` で検索文字列と選択中タグを同時に解除するようにしました。
 - 既存のタグ専用 `Clear` リンクを置き換え、検索とタグの両方を一度にリセットできる導線へ整理しました。
 - secondary 系の既存 `Button` を利用し、既存テーマ変数に沿う見た目にしています。

## 検証方法
1. `source ~/.nvm/nvm.sh && nvm use v20.20.0 >/dev/null && npm run build`
2. Home画面で検索文字列を入力し、`Clear filters` ボタンが表示されて入力値が一括で解除されることを確認する。
3. Home画面でタグを1つ以上選択し、`Clear filters` 実行後にタグ選択が解除されてカード一覧が全件表示に戻ることを確認する。

## スコープ
#### スコープ内:
 - Home画面の検索文字列とタグ選択をまとめて解除するUIと状態更新の追加
 - フィルタ解除後に一覧を全件表示へ戻す挙動の維持

#### スコープ外:
 - 検索条件のlocalStorage永続化
 - ソート機能追加
 - タグ編集/削除
 - UIデザインの全面改修

#### 学習・実証環境としての影響（該当する場合）:
 - なし

## リスク / トレードオフ
 - 既存のタグ専用 `Clear` リンクを、検索条件も含めて解除する単一ボタンに置き換えています。

#### 破壊的変更の可能性（ある場合は明記）:
 - なし

#### スクリーンショット（任意）
 - なし

## フォローアップ
 - なし

## 未解決の質問
 - なし
